### PR TITLE
feat(warehouse): add UI for viewing warehouse detail

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/staff/warehouses/[id]/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/staff/warehouses/[id]/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { getWarehouseById } from '@/lib/api/warehouses';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+
+export default function WarehouseDetailPage() {
+  const { id } = useParams();
+  const [warehouse, setWarehouse] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchWarehouse = async () => {
+      try {
+        const res = await getWarehouseById(id as string);
+        if (res.status === 1 && res.data) {
+          setWarehouse(res.data);
+        } else {
+          alert('❌ Không thể lấy dữ liệu kho: ' + res.message);
+        }
+      } catch (error) {
+        alert('❌ Lỗi khi tải chi tiết kho');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchWarehouse();
+  }, [id]);
+
+  if (loading) return <p className="p-4">Đang tải dữ liệu...</p>;
+  if (!warehouse) return <p className="p-4">Không tìm thấy kho.</p>;
+
+  return (
+    <div className="min-h-screen bg-amber-50 p-6">
+      <Card className="max-w-2xl mx-auto">
+        <CardHeader className="flex justify-between items-center">
+          <CardTitle>Chi tiết kho</CardTitle>
+          <Link href="/dashboard/staff/warehouses">
+            <Button variant="outline">← Quay lại danh sách</Button>
+          </Link>
+        </CardHeader>
+
+        <CardContent className="space-y-4 text-sm text-gray-700">
+          <p><strong>Mã kho (GUID):</strong> {warehouse.warehouseId}</p>
+          <p><strong>Mã kho:</strong> {warehouse.warehouseCode}</p>
+          <p><strong>Tên kho:</strong> {warehouse.name}</p>
+          <p><strong>Vị trí:</strong> {warehouse.location}</p>
+          <p><strong>Dung lượng:</strong> {warehouse.capacity?.toLocaleString()} kg</p>
+          <p><strong>Người quản lý:</strong> {warehouse.managerName}</p>
+          <p><strong>Ngày tạo:</strong> {new Date(warehouse.createdAt).toLocaleString()}</p>
+          <p><strong>Ngày cập nhật:</strong> {new Date(warehouse.updatedAt).toLocaleString()}</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/staff/warehouses/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/staff/warehouses/page.tsx
@@ -109,7 +109,7 @@ export default function WarehouseListPage() {
                     <td className="p-3">{w.location}</td>
                     <td className="p-3">{w.capacity?.toLocaleString()} kg</td>
                     <td className="p-3 space-x-2">
-                      <Link href={`/dashboard/business/warehouses/${w.warehouseId}`}>
+                      <Link href={`/dashboard/staff/warehouses/${w.warehouseId}`}>
                         <Button variant="outline" size="sm">
                           <Eye className="w-4 h-4 mr-1" /> Xem
                         </Button>


### PR DESCRIPTION
☕ Feature: [Business Staff] – Warehouse Detail View UI
📌 Objective
Implement the frontend interface for viewing detailed information of a warehouse. This feature is part of the warehouse management flow, targeted at Business Staff users.

✅ Main Changes
Added new UI page to view detailed warehouse information

Fetched warehouse data via API and displayed fields including name, location, capacity, etc.

Updated routing to support dynamic detail view

Basic responsive layout implemented

📁 Affected Files
app/dashboard/staff/warehouses/[id]/page.tsx

lib/api/warehouses.ts

(Other shared UI components if reused)

🧪 How to Test
Navigate to: /dashboard/staff/warehouses

Click "View" (Xem) on any warehouse to open detail view

Ensure the page displays:

Warehouse ID, Name, Location, Capacity

Navigation back to list

🧪 Test Cases
 ✅ Detail page loads when valid ID is provided

 ❌ Error message shown for invalid or missing ID

 ✅ Layout renders properly on both desktop and mobile

🔍 Notes
Uses @/components/ui for layout and buttons

Data is fetched from real API using token

⚠️ Ensure BE allows Business Staff to access GET /api/Warehouses/{id}. Add BusinessStaff to [Authorize] attribute in the controller if needed.

🔗 Related
Module: Warehouse

Role: BusinessStaff

