### PR TITLE
eat(crop-season): add toast-based error handling, loading spinner, a…

### DIFF
--- a/DakLakCoffeeSupplyChain/package-lock.json
+++ b/DakLakCoffeeSupplyChain/package-lock.json
@@ -26,6 +26,7 @@
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
+        "sonner": "^2.0.6",
         "tailwind-merge": "^3.3.1",
         "tailwind-variants": "^1.0.0",
         "uuid": "^11.1.0"
@@ -6726,6 +6727,16 @@
       "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.6.tgz",
+      "integrity": "sha512-yHFhk8T/DK3YxjFQXIrcHT1rGEeTLliVzWbO0xN8GberVun2RiBnxAjXAYpZrqwEVHBG9asI/Li8TAAhN9m59Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/DakLakCoffeeSupplyChain/package.json
+++ b/DakLakCoffeeSupplyChain/package.json
@@ -27,6 +27,7 @@
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
+    "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
     "tailwind-variants": "^1.0.0",
     "uuid": "^11.1.0"

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/layout.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/layout.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import HeaderDashboard from "@/components/layout/HeaderDashboard";
 import {
@@ -8,6 +8,7 @@ import {
   SidebarGroup,
 } from "@/components/ui/sidebar";
 import { useState, useEffect } from "react";
+import { Toaster } from "sonner"; // ✅ thêm dòng này
 
 export default function AdminLayout({
   children,
@@ -23,7 +24,7 @@ export default function AdminLayout({
   }, []);
 
   return (
-    <div className="flex h-screen  w-full bg-[#fefaf4] overflow-hidden">
+    <div className="flex h-screen w-full bg-[#fefaf4] overflow-hidden">
       {/* Sidebar */}
       <Sidebar defaultCollapsed={isCollapsed} onCollapseChange={setIsCollapsed}>
         <SidebarContent>
@@ -36,11 +37,13 @@ export default function AdminLayout({
         className={`flex flex-col flex-1 transition-all duration-300 ${isCollapsed ? "ml-[64px]" : "ml-[260px]"
           }`}
       >
-        <div className="shrink-0 ">
+        <div className="shrink-0">
           <HeaderDashboard />
         </div>
-        <div className="flex-1 p-5 overflow-auto	">{children}</div>
+        <div className="flex-1 p-5 overflow-auto">{children}</div>
       </div>
+
+      <Toaster richColors /> {/* ✅ thêm Toaster ở cuối cùng */}
     </div>
   );
 }

--- a/DakLakCoffeeSupplyChain/src/components/ui/AppToast.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/ui/AppToast.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { toast } from "sonner";
+
+export const AppToast = {
+    success: (message: string) => toast.success(message),
+    error: (message: string) => toast.error(message),
+    warning: (message: string) => toast.warning(message),
+    info: (message: string) => toast(message),
+};

--- a/DakLakCoffeeSupplyChain/src/components/ui/LoadingSpinner.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/ui/LoadingSpinner.tsx
@@ -1,0 +1,7 @@
+export default function LoadingSpinner() {
+    return (
+        <div className="flex justify-center items-center py-8">
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-orange-500 border-t-transparent" />
+        </div>
+    );
+}

--- a/DakLakCoffeeSupplyChain/src/lib/utils.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/utils.ts
@@ -1,13 +1,17 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 import { DEFAULT_ERROR_MESSAGE } from "./constrant/httpErrors";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }
 
-// Chỉ nên dùng ở hàm catch trong try catch, xem api resendVerificationEmail ở auth làm ví dụ
 export function getErrorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message;
+  const axiosMsg = (error as any)?.response?.data?.message;
+  if (typeof axiosMsg === 'string') return axiosMsg;
+
+  const msg = (error as any)?.message;
+  if (typeof msg === 'string') return msg;
+
   return DEFAULT_ERROR_MESSAGE;
 }


### PR DESCRIPTION
### Changes

- ✅ Replaced native alerts with toast-based feedback (`AppToast`) for better UX
- ✅ Added `LoadingSpinner` component and integrated loading state in Create Crop Season
- ✅ Improved error handling in `createCropSeason()`:
  - Throw error if `ServiceResult.code !== 201`
  - Ensure backend error message is surfaced to the UI
- ✅ Updated `getErrorMessage()` to support `ServiceResult` shape
- ✅ UI polish: disable button during submission, show correct state in case of failure

### Why

Previously, API errors were swallowed or not clearly shown, making it hard for users to correct inputs (e.g. duplicate season or invalid date range). This PR improves feedback flow and prevents confusion.

### Screenshots

> Add screenshots or demo gif here if helpful.
