### PR TITLE
feat(farmer): enable soft delete for crop seasons with UI update afte…

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-seasons/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-seasons/page.tsx
@@ -24,8 +24,12 @@ export default function FarmerCropSeasonsPage() {
     const [currentPage, setCurrentPage] = useState(1);
     const [search, setSearch] = useState('');
     const [selectedStatus, setSelectedStatus] = useState<string | null>(null);
-
     const pageSize = 10;
+
+    const handleSeasonDeleted = (deletedId: string) => {
+        setCropSeasons(prev => prev.filter(season => season.cropSeasonId !== deletedId));
+    };
+
 
     useEffect(() => {
         setCurrentPage(1);
@@ -120,7 +124,11 @@ export default function FarmerCropSeasonsPage() {
                             </thead>
                             <tbody>
                                 {pagedSeasons.map((season) => (
-                                    <CropSeasonCard key={season.cropSeasonId} season={season} />
+                                    <CropSeasonCard
+                                        key={season.cropSeasonId}
+                                        season={season}
+                                        onDeleted={handleSeasonDeleted}
+                                    />
                                 ))}
                             </tbody>
                         </table>

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/layout.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/layout.tsx
@@ -25,7 +25,6 @@ export default function AdminLayout({
 
   return (
     <div className="flex h-screen w-full bg-[#fefaf4] overflow-hidden">
-      {/* Sidebar */}
       <Sidebar defaultCollapsed={isCollapsed} onCollapseChange={setIsCollapsed}>
         <SidebarContent>
           <SidebarGroup />

--- a/DakLakCoffeeSupplyChain/src/lib/api/cropSeasons.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/cropSeasons.ts
@@ -45,6 +45,13 @@ export interface CropSeasonListItem {
   status: string;
 }
 
+interface ServiceResult<T = any> {
+  code: number | string;
+  message: string;
+  data: T | null;
+}
+
+
 // ========== API FUNCTIONS ==========
 
 // Lấy tất cả mùa vụ (dành cho Admin hoặc Manager)
@@ -94,14 +101,20 @@ export async function getCropSeasonById(id: string): Promise<CropSeason | null> 
   }
 }
 
-// Xoá mùa vụ (chỉ Admin hoặc Farmer chủ mùa vụ)
-export async function deleteCropSeasonById(id: string): Promise<boolean> {
+export async function deleteCropSeasonById(id: string): Promise<{ code: any; message: string }> {
   try {
-    await api.delete(`/CropSeasons/${id}`);
-    return true;
-  } catch (err) {
-    console.error("Lỗi deleteCropSeasonById:", err);
-    return false;
+    const res = await api.patch(`/CropSeasons/soft-delete/${id}`); // ✅ Dùng PATCH thay vì DELETE
+    return {
+      code: 200,
+      message: res.data || 'Xoá thành công',
+    };
+  } catch (err: any) {
+    const message =
+      err?.response?.data || err?.message || 'Xoá mùa vụ thất bại.';
+    return {
+      code: 400,
+      message,
+    };
   }
 }
 
@@ -117,11 +130,6 @@ export async function updateCropSeason(id: string, data: Partial<CropSeason>): P
 }
 
 // Tạo mới mùa vụ
-interface ServiceResult<T = any> {
-  code: number | string;
-  message: string;
-  data: T | null;
-}
 
 export async function createCropSeason(data: Partial<CropSeason>): Promise<ServiceResult> {
   try {


### PR DESCRIPTION
- Implemented soft delete functionality for crop seasons on the farmer dashboard.
- Updated UI to reflect changes immediately after deletion without manual reload.
- Only allow delete button to show when crop season status is `Cancelled`.
- Modified API call to use PATCH `/soft-delete` instead of DELETE.
