### PR TITLE
feat(farmer): fetch available farming commitments for crop season cre…

### DIFF
--- a/DakLakCoffeeSupplyChain/src/lib/api/axios.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/axios.ts
@@ -7,7 +7,6 @@ if (!apiUrl) {
   throw new Error("API URL is not defined in environment variables.");
 }
 
-console.log("🌐 API Base URL:", apiUrl);
 
 const api: AxiosInstance = axios.create({
   baseURL: apiUrl,
@@ -19,7 +18,7 @@ const api: AxiosInstance = axios.create({
 
 api.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem("token"); // hoặc "access_token"
+    const token = localStorage.getItem("token");
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
@@ -36,10 +35,7 @@ api.interceptors.response.use(
     if (error.response) {
       const status = error.response.status;
       let message = "";
-      // Nếu dữ liệu trả về là chuỗi không rỗng, sử dụng nó làm thông báo lỗi
-      // Nếu không, sử dụng thông báo lỗi mặc định hoặc thông báo theo status code
-      // Nếu muốn đánh chặn truy cập vì unauthorized thì đừng làm ở đây mà hãy làm ở phía dashboard page, sau khi người dùng nhập url dashboard mà chưa đăng nhập thì sẽ chuyển hướng về trang unauthorized hoặc trang đăng nhập.
-      if (typeof error.response.data === "string" && error.response.data.trim() !== "") {
+       if (typeof error.response.data === "string" && error.response.data.trim() !== "") {
         message = error.response.data;
       } else {
         message =

--- a/DakLakCoffeeSupplyChain/src/lib/api/farmingCommitments.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/farmingCommitments.ts
@@ -1,0 +1,24 @@
+// lib/api/farmingCommitments.ts
+import api from "@/lib/api/axios";
+
+export interface FarmingCommitmentItem {
+  commitmentId: string;
+  commitmentCode: string;
+  commitmentName: string;
+  farmerName: string;
+  confirmedPrice: number;
+  committedQuantity: number;
+  estimatedDeliveryStart: string;
+  estimatedDeliveryEnd: string;
+  status: number;
+}
+
+export async function getFarmerCommitments(): Promise<FarmingCommitmentItem[]> {
+  try {
+    const res = await api.get<FarmingCommitmentItem[]>("/FarmingCommitment/Farmer");
+    return res.data;
+  } catch (err) {
+    console.error("Lỗi getFarmerCommitments:", err);
+    return [];
+  }
+}


### PR DESCRIPTION
feat(farmer): fetch available farming commitments for crop season creation

- Updated create crop season page to fetch valid commitments using /api/FarmingCommitment/Farmer
- Displayed available commitments in a dropdown list for selection
- Updated axios interceptor to correctly attach token from localStorage
- Handled 403 forbidden error and showed appropriate toast notification
- Improved logging for debugging API authorization issues
