### PR TITLE
feat(crop-season): add edit page and enum-based status handling for d…

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-seasons/[id]/details/create/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-seasons/[id]/details/create/page.tsx
@@ -1,13 +1,181 @@
 'use client';
-import { useParams } from 'next/navigation';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { AppToast } from '@/components/ui/AppToast';
+import { getErrorMessage } from '@/lib/utils';
+import { CoffeeType, getCoffeeTypes } from '@/lib/api/coffeeType';
+import { createCropSeasonDetail } from '@/lib/api/cropSeasonDetail ';
 
 export default function CreateCropSeasonDetailPage() {
     const params = useParams();
+    const router = useRouter();
     const cropSeasonId = params.id as string;
 
+    const [form, setForm] = useState({
+        coffeeTypeId: '',
+        areaAllocated: '',
+        plannedQuality: '',
+        expectedHarvestStart: '',
+        expectedHarvestEnd: '',
+        estimatedYield: '',
+        status: 0,
+    });
+
+    const [coffeeTypes, setCoffeeTypes] = useState<CoffeeType[]>([]);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    // Fetch coffee types
+    useEffect(() => {
+        async function fetchCoffeeTypes() {
+            try {
+                const data = await getCoffeeTypes();
+                setCoffeeTypes(data);
+            } catch (err) {
+                AppToast.error('Không thể tải danh sách loại cà phê');
+            }
+        }
+
+        fetchCoffeeTypes();
+    }, []);
+
+    const handleChange = (
+        e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+    ) => {
+        const { name, value } = e.target;
+        setForm((prev) => ({ ...prev, [name]: value }));
+    };
+
+    const handleSubmit = async () => {
+        const requiredFields = [
+            'coffeeTypeId',
+            'areaAllocated',
+            'plannedQuality',
+            'expectedHarvestStart',
+            'expectedHarvestEnd',
+        ];
+        const missing = requiredFields.filter((f) => !form[f as keyof typeof form]);
+        if (missing.length > 0) {
+            AppToast.error('Vui lòng điền đầy đủ các trường bắt buộc.');
+            return;
+        }
+
+        setIsSubmitting(true);
+        try {
+            await createCropSeasonDetail({
+                cropSeasonId,
+                coffeeTypeId: form.coffeeTypeId,
+                areaAllocated: parseFloat(form.areaAllocated),
+                plannedQuality: form.plannedQuality,
+                expectedHarvestStart: form.expectedHarvestStart,
+                expectedHarvestEnd: form.expectedHarvestEnd,
+                estimatedYield: parseFloat(form.estimatedYield || '0'),
+                status: Number(form.status),
+            });
+            AppToast.success('Tạo vùng trồng thành công!');
+            router.push(`/dashboard/farmer/crop-seasons/${cropSeasonId}`);
+        } catch (err) {
+            AppToast.error(getErrorMessage(err));
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
     return (
-        <div>
-            <h1>Thêm vùng trồng cho mùa vụ {cropSeasonId}</h1>
+        <div className="max-w-2xl mx-auto py-10 px-4">
+            <Card>
+                <CardHeader>
+                    <CardTitle>Thêm vùng trồng cho mùa vụ</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <div>
+                        <Label>Loại cà phê</Label>
+                        <select
+                            name="coffeeTypeId"
+                            value={form.coffeeTypeId}
+                            onChange={handleChange}
+                            className="w-full border rounded px-2 py-2"
+                            required
+                        >
+                            <option value="">-- Chọn loại cà phê --</option>
+                            {coffeeTypes.map((type) => (
+                                <option
+                                    key={type.coffeeTypeId}
+                                    value={type.coffeeTypeId}
+                                    title={type.description || ''}
+                                >
+                                    {type.typeName}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+
+                    <div>
+                        <Label>Diện tích (ha)</Label>
+                        <Input
+                            type="number"
+                            name="areaAllocated"
+                            value={form.areaAllocated}
+                            onChange={handleChange}
+                            required
+                        />
+                    </div>
+
+                    <div>
+                        <Label>Chất lượng dự kiến</Label>
+                        <Input
+                            name="plannedQuality"
+                            value={form.plannedQuality}
+                            onChange={handleChange}
+                            required
+                        />
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-4">
+                        <div>
+                            <Label htmlFor="expectedHarvestStart">Bắt đầu thu hoạch</Label>
+                            <Input
+                                type="date"
+                                name="expectedHarvestStart"
+                                value={form.expectedHarvestStart}
+                                onChange={handleChange}
+                                required
+                            />
+                        </div>
+                        <div>
+                            <Label htmlFor="expectedHarvestEnd">Kết thúc thu hoạch</Label>
+                            <Input
+                                type="date"
+                                name="expectedHarvestEnd"
+                                value={form.expectedHarvestEnd}
+                                onChange={handleChange}
+                                required
+                            />
+                        </div>
+                    </div>
+
+                    <div>
+                        <Label>Năng suất ước tính (tấn)</Label>
+                        <Input
+                            type="number"
+                            name="estimatedYield"
+                            value={form.estimatedYield}
+                            onChange={handleChange}
+                        />
+                    </div>
+
+                    <div className="flex justify-end">
+                        <Button onClick={handleSubmit} disabled={isSubmitting}>
+                            {isSubmitting ? 'Đang tạo...' : 'Tạo vùng trồng'}
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
         </div>
     );
 }

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-seasons/[id]/details/edit/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-seasons/[id]/details/edit/page.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getCoffeeTypes, CoffeeType } from '@/lib/api/coffeeType';
+import { AppToast } from '@/components/ui/AppToast';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+
+import {
+    CropSeasonDetailStatusMap,
+    CropSeasonDetailStatusValue,
+    CropSeasonDetailStatusNumberToValue,
+    CropSeasonDetailStatusValueToNumber,
+} from '@/lib/constrant/cropSeasonDetailStatus';
+import { getCropSeasonDetailById, updateCropSeasonDetail } from '@/lib/api/cropSeasonDetail ';
+
+
+
+interface Props {
+    detailId: string;
+    cropSeasonId: string;
+    onClose: () => void;
+    onSuccess: () => void;
+}
+
+export default function UpdateCropSeasonDetailPage({
+    detailId,
+    cropSeasonId,
+    onClose,
+    onSuccess,
+}: Props) {
+    const [form, setForm] = useState({
+        coffeeTypeId: '',
+        areaAllocated: '',
+        plannedQuality: '',
+        expectedHarvestStart: '',
+        expectedHarvestEnd: '',
+        estimatedYield: '',
+        status: 'Planned' as CropSeasonDetailStatusValue,
+    });
+
+    const [coffeeTypes, setCoffeeTypes] = useState<CoffeeType[]>([]);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const [types, detail] = await Promise.all([
+                    getCoffeeTypes(),
+                    getCropSeasonDetailById(detailId),
+                ]);
+
+                setCoffeeTypes(types);
+
+                setForm({
+                    coffeeTypeId: detail.coffeeTypeId,
+                    areaAllocated: detail.areaAllocated?.toString() || '',
+                    plannedQuality: detail.plannedQuality || '',
+                    expectedHarvestStart: detail.expectedHarvestStart,
+                    expectedHarvestEnd: detail.expectedHarvestEnd,
+                    estimatedYield: detail.estimatedYield?.toString() || '',
+                    status: CropSeasonDetailStatusNumberToValue[detail.status],
+                });
+            } catch (err) {
+                AppToast.error('Không thể tải dữ liệu vùng trồng');
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchData();
+    }, [detailId]);
+
+    const handleChange = (
+        e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+    ) => {
+        const { name, value } = e.target;
+        setForm((prev) => ({
+            ...prev,
+            [name]: value,
+        }));
+    };
+
+    const handleSubmit = async () => {
+        const {
+            coffeeTypeId,
+            areaAllocated,
+            plannedQuality,
+            expectedHarvestStart,
+            expectedHarvestEnd,
+            estimatedYield,
+            status,
+        } = form;
+
+        const parsedStatus = CropSeasonDetailStatusValueToNumber[status];
+        console.log('🔁 parsedStatus (number):', parsedStatus);
+
+        const payload = {
+            detailId,
+            coffeeTypeId,
+            expectedHarvestStart,
+            expectedHarvestEnd,
+            estimatedYield: parseFloat(estimatedYield || '0'),
+            areaAllocated: parseFloat(areaAllocated),
+            plannedQuality,
+            status: parsedStatus,
+        };
+
+        console.log('🔍 form.status (string):', status);
+        console.log('✅ Payload gửi lên:', payload);
+
+        setIsSubmitting(true);
+        try {
+            await updateCropSeasonDetail(detailId, payload);
+            AppToast.success('Cập nhật vùng trồng thành công!');
+            onSuccess();
+            onClose();
+        } catch (err) {
+            AppToast.error((err as any)?.message || 'Cập nhật thất bại');
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    if (isLoading) return <p className="p-4 text-sm">Đang tải dữ liệu...</p>;
+
+    return (
+        <div className="fixed inset-0 bg-black bg-opacity-30 flex justify-center items-center z-50">
+            <div className="bg-white w-full max-w-2xl rounded-xl p-6 shadow-xl">
+                <h2 className="text-lg font-semibold mb-4">Chỉnh sửa vùng trồng</h2>
+                <div className="space-y-4">
+                    <div>
+                        <Label>Loại cà phê</Label>
+                        <select
+                            name="coffeeTypeId"
+                            value={form.coffeeTypeId}
+                            onChange={handleChange}
+                            className="w-full border rounded px-2 py-2"
+                        >
+                            <option value="">-- Chọn loại cà phê --</option>
+                            {coffeeTypes.map((type) => (
+                                <option key={type.coffeeTypeId} value={type.coffeeTypeId}>
+                                    {type.typeName}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+
+                    <div>
+                        <Label>Diện tích (ha)</Label>
+                        <Input
+                            type="number"
+                            name="areaAllocated"
+                            value={form.areaAllocated}
+                            onChange={handleChange}
+                        />
+                    </div>
+
+                    <div>
+                        <Label>Chất lượng dự kiến</Label>
+                        <Input
+                            name="plannedQuality"
+                            value={form.plannedQuality}
+                            onChange={handleChange}
+                        />
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-4">
+                        <div>
+                            <Label>Bắt đầu thu hoạch</Label>
+                            <Input
+                                type="date"
+                                name="expectedHarvestStart"
+                                value={form.expectedHarvestStart}
+                                onChange={handleChange}
+                            />
+                        </div>
+                        <div>
+                            <Label>Kết thúc thu hoạch</Label>
+                            <Input
+                                type="date"
+                                name="expectedHarvestEnd"
+                                value={form.expectedHarvestEnd}
+                                onChange={handleChange}
+                            />
+                        </div>
+                    </div>
+
+                    <div>
+                        <Label>Năng suất ước tính (tấn)</Label>
+                        <Input
+                            type="number"
+                            name="estimatedYield"
+                            value={form.estimatedYield}
+                            onChange={handleChange}
+                        />
+                    </div>
+
+                    <div>
+                        <Label>Trạng thái</Label>
+                        <select
+                            name="status"
+                            value={form.status}
+                            onChange={handleChange}
+                            className="w-full border rounded px-2 py-2"
+                        >
+                            {Object.entries(CropSeasonDetailStatusMap).map(([key, val]) => (
+                                <option key={key} value={key}>
+                                    {val.label}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+
+                    <div className="flex justify-end gap-2">
+                        <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
+                            Huỷ
+                        </Button>
+                        <Button onClick={handleSubmit} disabled={isSubmitting}>
+                            {isSubmitting ? 'Đang cập nhật...' : 'Cập nhật'}
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-seasons/create/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-seasons/create/page.tsx
@@ -35,6 +35,7 @@ export default function CreateCropSeasonPage() {
 
         fetchCommitments();
     }, []);
+
     const [isSubmitting, setIsSubmitting] = useState(false);
 
     const handleChange = (

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-seasons/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-seasons/page.tsx
@@ -8,7 +8,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { ChevronLeft, ChevronRight, Search } from 'lucide-react';
-import { CropSeasonStatusMap, CropSeasonStatusValue } from '@/lib/constrant/cropSeasonStatus';
+import { CropSeasonStatusValue } from '@/lib/constrant/cropSeasonStatus';
 import { cn } from '@/lib/utils';
 import CropSeasonCard from '@/components/crop-seasons/CropSeasonCard';
 import FilterStatusPanel from '@/components/crop-seasons/FilterStatusPanel';
@@ -77,7 +77,6 @@ export default function FarmerCropSeasonsPage() {
     });
 
     const router = useRouter();
-
     return (
         <div className="flex min-h-screen bg-amber-50 p-6 gap-6">
             <aside className="w-64 space-y-4">

--- a/DakLakCoffeeSupplyChain/src/components/crop-seasons/CropSeasonDetailTable.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/crop-seasons/CropSeasonDetailTable.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import StatusBadge from '@/components/crop-seasons/StatusBadge';
+import {
+    CropSeasonDetailStatusEnum,
+    CropSeasonDetailStatusMap,
+} from '@/lib/constrant/cropSeasonDetailStatus';
+import { useAuth } from '@/lib/hooks/useAuth';
+import { toast } from 'sonner';
+import { CropSeasonDetail } from '@/lib/api/cropSeasons';
+import { Edit, Trash } from 'lucide-react';
+import { deleteCropSeasonDetail } from '@/lib/api/cropSeasonDetail ';
+import UpdateCropSeasonDetailPage from '@/app/dashboard/farmer/crop-seasons/[id]/details/edit/page';
+
+
+interface Props {
+    details: CropSeasonDetail[];
+    cropSeasonId: string;
+    onReload: () => void;
+}
+
+export default function CropSeasonDetailTable({ details, cropSeasonId, onReload }: Props) {
+    const { user } = useAuth();
+    const [editingDetailId, setEditingDetailId] = useState<string | null>(null);
+
+    const formatDate = (date?: string) => {
+        if (!date) return 'Chưa cập nhật';
+        const d = new Date(date);
+        return isNaN(d.getTime()) ? 'Chưa cập nhật' : d.toLocaleDateString('vi-VN');
+    };
+
+    const handleDelete = async (detailId: string, name: string) => {
+        const confirmDelete = window.confirm(`Bạn có chắc muốn xoá vùng trồng: ${name}?`);
+        if (!confirmDelete) return;
+
+        try {
+            await deleteCropSeasonDetail(detailId);
+            toast.success('Xoá vùng trồng thành công');
+            onReload();
+        } catch (err: any) {
+            toast.error(err.message || 'Xoá vùng trồng thất bại');
+        }
+    };
+
+    if (details.length === 0) {
+        return <p className="text-sm text-muted-foreground">Không có dữ liệu vùng trồng</p>;
+    }
+
+    return (
+        <>
+            <table className="w-full text-sm border">
+                <thead className="bg-gray-100">
+                    <tr>
+                        <th className="text-left px-3 py-2">Loại cà phê</th>
+                        <th className="text-left px-3 py-2">Diện tích</th>
+                        <th className="text-left px-3 py-2">Chất lượng</th>
+                        <th className="text-left px-3 py-2">Năng suất (dự kiến)</th>
+                        <th className="text-left px-3 py-2">Năng suất thực</th>
+                        <th className="text-left px-3 py-2">Thời gian thu hoạch</th>
+                        <th className="text-left px-3 py-2">Trạng thái</th>
+                        <th className="text-left px-3 py-2">Hành động</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {details.map((detail) => (
+                        <tr key={detail.detailId} className="border-t">
+                            <td className="px-3 py-2">{detail.typeName}</td>
+                            <td className="px-3 py-2">{detail.areaAllocated} ha</td>
+                            <td className="px-3 py-2">{detail.plannedQuality}</td>
+                            <td className="px-3 py-2">{detail.estimatedYield ?? '-'} tấn</td>
+                            <td className="px-3 py-2">
+                                {detail.actualYield !== null
+                                    ? `${detail.actualYield} tấn`
+                                    : <span className="italic text-muted-foreground">Chưa thu hoạch</span>}
+                            </td>
+                            <td className="px-3 py-2">
+                                {detail.expectedHarvestStart
+                                    ? `${formatDate(detail.expectedHarvestStart)} – ${formatDate(detail.expectedHarvestEnd)}`
+                                    : '-'}
+                            </td>
+                            <td className="px-3 py-2">
+                                <StatusBadge status={detail.status} map={CropSeasonDetailStatusMap} />
+                            </td>
+                            <td className="px-3 py-2 space-x-1">
+                                <Button
+                                    size="icon"
+                                    variant="outline"
+                                    onClick={() => setEditingDetailId(detail.detailId)}
+                                >
+                                    <Edit className="w-4 h-4" />
+                                </Button>
+                                <Button
+                                    size="icon"
+                                    variant="destructive"
+                                    onClick={() => handleDelete(detail.detailId, detail.typeName)}
+                                >
+                                    <Trash className="w-4 h-4" />
+                                </Button>
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+
+            {editingDetailId && (
+                <UpdateCropSeasonDetailPage
+                    detailId={editingDetailId}
+                    cropSeasonId={cropSeasonId}
+                    onClose={() => setEditingDetailId(null)}
+                    onSuccess={onReload}
+                />
+            )}
+        </>
+    );
+}

--- a/DakLakCoffeeSupplyChain/src/components/crop-seasons/StatusBadge.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/crop-seasons/StatusBadge.tsx
@@ -6,29 +6,31 @@ import { cn } from '@/lib/utils';
 type StatusInfo = {
     label: string;
     color: 'green' | 'yellow' | 'blue' | 'red' | 'gray';
-    icon?: string;
+    icon?: string; // chưa dùng nhưng có thể thêm sau
 };
 
 type Props = {
     status: string;
-    map: Record<string, StatusInfo>; // map cho CropSeason hoặc CropSeasonDetail
+    map: Record<string, StatusInfo>;
 };
 
 export default function StatusBadge({ status, map }: Props) {
     const info = map[status];
 
     const colorClass = cn(
-        'inline-flex items-center justify-center w-36 h-8 px-2 py-1 text-xs font-medium rounded-full border text-center',
-        info?.color === 'green'
-            ? 'bg-green-100 text-green-700 border-green-500'
-            : info?.color === 'yellow'
-                ? 'bg-yellow-100 text-yellow-700 border-yellow-500'
-                : info?.color === 'blue'
-                    ? 'bg-blue-100 text-blue-700 border-blue-500'
-                    : info?.color === 'red'
-                        ? 'bg-red-100 text-red-700 border-red-500'
-                        : 'bg-gray-100 text-gray-700 border-gray-400'
+        'inline-flex items-center justify-center min-w-[5rem] h-7 px-2 text-xs font-medium rounded-full border whitespace-nowrap',
+        {
+            'bg-green-100 text-green-700 border-green-500': info?.color === 'green',
+            'bg-yellow-100 text-yellow-700 border-yellow-500': info?.color === 'yellow',
+            'bg-blue-100 text-blue-700 border-blue-500': info?.color === 'blue',
+            'bg-red-100 text-red-700 border-red-500': info?.color === 'red',
+            'bg-gray-100 text-gray-700 border-gray-400': !info || info?.color === 'gray',
+        }
     );
 
-    return <Badge className={colorClass}>{info?.label || status}</Badge>;
+    return (
+        <Badge className={colorClass}>
+            {info?.label || status}
+        </Badge>
+    );
 }

--- a/DakLakCoffeeSupplyChain/src/components/ui/dialog.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/ui/dialog.tsx
@@ -50,29 +50,39 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  title,
+  description,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
+  title?: React.ReactNode
+  description?: React.ReactNode
 }) {
   return (
-    <DialogPortal data-slot="dialog-portal">
+    <DialogPortal>
       <DialogOverlay />
       <DialogPrimitive.Content
-        data-slot="dialog-content"
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
         {...props}
       >
+        {(title || description) && (
+          <div className="space-y-1">
+            {title && <DialogTitle>{title}</DialogTitle>}
+            {description && <DialogDescription>{description}</DialogDescription>}
+          </div>
+        )}
+
         {children}
+
         {showCloseButton && (
           <DialogPrimitive.Close
-            data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="absolute top-4 right-4 opacity-70 hover:opacity-100 transition-opacity focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
           >
-            <XIcon />
-            <span className="sr-only">Close</span>
+            <XIcon className="w-4 h-4" />
+            <span className="sr-only">Đóng</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Content>
@@ -110,7 +120,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      className={cn("text-lg font-semibold leading-none", className)}
       {...props}
     />
   )
@@ -123,7 +133,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
   )

--- a/DakLakCoffeeSupplyChain/src/lib/api/CropSeasonDetail .ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/CropSeasonDetail .ts
@@ -1,28 +1,106 @@
+import api from '@/lib/api/axios';
+import { getErrorMessage } from '@/lib/utils';
 
-import api from "./axios";
+// ================== TYPES ==================
+// ================== TYPES ==================
 
-export type CreateCropSeasonDetail = {
+export type CropSeasonDetail = {
+  success: any;
+  error: string;
+  detailId: string;
   cropSeasonId: string;
   coffeeTypeId: string;
   expectedHarvestStart: string;
   expectedHarvestEnd: string;
   estimatedYield: number;
-  actualYield?: number | null; // optional
+  actualYield?: number | null;
   areaAllocated: number;
   plannedQuality: string;
   qualityGrade?: string;
   status: number;
-   farmerId: string;
+  farmerId: string;
   farmerName: string;
 };
 
+export type CropSeasonDetailCreatePayload = Omit<
+  CropSeasonDetail,
+  'detailId' | 'farmerId' | 'farmerName' | 'qualityGrade' | 'actualYield'
+>;
 
-export async function createCropSeasonDetail(data: CreateCropSeasonDetail): Promise<void> {
+// ✅ Cập nhật lại chuẩn payload update
+export type CropSeasonDetailUpdatePayload = {
+  detailId: string;               // ✅ Required
+  coffeeTypeId: string;           // ✅ Required
+  expectedHarvestStart?: string; // gửi đúng định dạng yyyy-MM-dd
+  expectedHarvestEnd?: string;
+  estimatedYield?: number;
+  areaAllocated?: number;
+  plannedQuality?: string;
+  status: number;                 // enum int
+};
+
+
+// ================== API FUNCTIONS ==================
+
+const baseUrl = '/CropSeasonDetails';
+
+export async function createCropSeasonDetail(
+  data: CropSeasonDetailCreatePayload
+): Promise<CropSeasonDetail> {
   try {
-    await api.post("/CropSeasonDetails", data);
+    const response = await api.post(baseUrl, data);
+    return response.data;
   } catch (err) {
-    console.error("Lỗi createCropSeasonDetail:", err);
-    throw new Error("Thêm vùng trồng thất bại");
+    console.error('Lỗi createCropSeasonDetail:', err);
+    throw new Error(getErrorMessage(err));
   }
 }
 
+export async function updateCropSeasonDetail(
+  detailId: string,
+  data: CropSeasonDetailUpdatePayload
+): Promise<CropSeasonDetail> {
+  try {
+    const response = await api.put(`${baseUrl}/${detailId}`, data);
+    return response.data;
+  } catch (err) {
+    console.error('Lỗi updateCropSeasonDetail:', err);
+    throw new Error(getErrorMessage(err) || 'Cập nhật vùng trồng thất bại');
+  }
+}
+
+export async function deleteCropSeasonDetail(
+  detailId: string
+): Promise<{ success: boolean }> {
+  try {
+    await api.delete(`${baseUrl}/${detailId}`);
+    return { success: true };
+  } catch (err) {
+    console.error('Lỗi deleteCropSeasonDetail:', err);
+    throw new Error(getErrorMessage(err) || 'Xoá vùng trồng thất bại');
+  }
+}
+
+export async function getCropSeasonDetailById(
+  detailId: string
+): Promise<CropSeasonDetail> {
+  try {
+    const response = await api.get(`${baseUrl}/${detailId}`);
+    return response.data;
+  } catch (err) {
+    console.error('Lỗi getCropSeasonDetailById:', err);
+    throw new Error(getErrorMessage(err) || 'Không thể lấy chi tiết vùng trồng');
+  }
+}
+
+export async function getCropSeasonDetailsByCropSeasonId(
+  cropSeasonId: string
+): Promise<CropSeasonDetail[]> {
+  try {
+    const response = await api.get(`${baseUrl}/by-cropSeason/${cropSeasonId}`);
+    return response.data;
+  } catch (err) {
+    console.error('Lỗi getCropSeasonDetailsByCropSeasonId:', err);
+    throw new Error(getErrorMessage(err) || 'Không thể lấy danh sách vùng trồng');
+  }
+}

--- a/DakLakCoffeeSupplyChain/src/lib/api/coffeeType.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/coffeeType.ts
@@ -1,0 +1,16 @@
+import api from "@/lib/api/axios";
+
+export type CoffeeType = {
+  coffeeTypeId: string;
+  typeName: string;
+  typeCode: string;
+  botanicalName?: string | null;
+  description?: string;
+  typicalRegion?: string;
+  specialtyLevel?: string;
+};
+
+export async function getCoffeeTypes(): Promise<CoffeeType[]> {
+  const response = await api.get("/CoffeeType");
+  return response.data;
+}

--- a/DakLakCoffeeSupplyChain/src/lib/constrant/cropSeasonDetailStatus.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/constrant/cropSeasonDetailStatus.ts
@@ -1,45 +1,45 @@
+export type CropSeasonDetailStatusValue = 'Planned' | 'InProgress' | 'Completed' | 'Cancelled';
+
 export enum CropSeasonDetailStatusEnum {
   Planned = 0,
-  Harvesting = 1,
-  Harvested = 2,
-  Completed = 3,
-  Cancelled = 4,
+  InProgress = 1,
+  Completed = 2,
+  Cancelled = 3,
 }
-
-export type CropSeasonDetailStatusValue = keyof typeof CropSeasonDetailStatusEnum;
 
 export const CropSeasonDetailStatusMap: Record<CropSeasonDetailStatusValue, {
   label: string;
-  color: 'green' | 'yellow' | 'blue' | 'red' | 'gray';
+  color: 'gray' | 'yellow' | 'green' | 'red';
 }> = {
   Planned: {
-    label: 'Lên kế hoạch',
+    label: 'Đã lên kế hoạch',
     color: 'gray',
   },
-  Harvesting: {
-    label: 'Đang thu hoạch',
+  InProgress: {
+    label: 'Đang canh tác',
     color: 'yellow',
   },
-  Harvested: {
-    label: 'Đã thu hoạch',
+  Completed: {
+    label: 'Đã hoàn thành',
     color: 'green',
   },
-  Completed: {
-    label: 'Hoàn thành',
-    color: 'blue',
-  },
   Cancelled: {
-    label: 'Đã hủy',
+    label: 'Đã huỷ',
     color: 'red',
   },
 };
 
-export function mapStatusFromEnum(value: number): CropSeasonDetailStatusValue {
-  return Object.keys(CropSeasonDetailStatusEnum).find(
-    (key) => CropSeasonDetailStatusEnum[key as keyof typeof CropSeasonDetailStatusEnum] === value
-  ) as CropSeasonDetailStatusValue;
-}
+// Mapping number <-> string
+export const CropSeasonDetailStatusNumberToValue: Record<number, CropSeasonDetailStatusValue> = {
+  0: 'Planned',
+  1: 'InProgress',
+  2: 'Completed',
+  3: 'Cancelled',
+};
 
-export function mapStatusToEnum(value: CropSeasonDetailStatusValue): number {
-  return CropSeasonDetailStatusEnum[value];
-}
+export const CropSeasonDetailStatusValueToNumber: Record<CropSeasonDetailStatusValue, number> = {
+  Planned: 0,
+  InProgress: 1,
+  Completed: 2,
+  Cancelled: 3,
+};

--- a/DakLakCoffeeSupplyChain/src/lib/utils.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/utils.ts
@@ -5,13 +5,23 @@ import { DEFAULT_ERROR_MESSAGE } from "./constrant/httpErrors";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
-
 export function getErrorMessage(error: unknown): string {
+  // Ưu tiên: lỗi trong response.message (thường là ServiceResult)
   const axiosMsg = (error as any)?.response?.data?.message;
   if (typeof axiosMsg === 'string') return axiosMsg;
 
+  // Xử lý lỗi dạng validation: response.data.errors
+  const validationErrors = (error as any)?.response?.data?.errors;
+  if (validationErrors && typeof validationErrors === 'object') {
+    return Object.entries(validationErrors)
+      .map(([field, messages]) => `${field}: ${(messages as string[]).join(', ')}`)
+      .join('; ');
+  }
+
+  // Fallback: lỗi thông thường từ err.message
   const msg = (error as any)?.message;
   if (typeof msg === 'string') return msg;
 
+  // Trường hợp không rõ: fallback mặc định
   return DEFAULT_ERROR_MESSAGE;
 }


### PR DESCRIPTION
feat(farmer/crop-season): add edit page and improve status handling

- Added edit page for CropSeasonDetail under `[id]/details/edit`
- Updated create and update pages to support status as enum
- Refactored `CropSeasonDetailTable` into standalone component
- Improved status rendering via `StatusBadge` and consistent mapping
- Enhanced `dialog.tsx` for better modal behavior
- Synced API (`CropSeasonDetail.ts`) with backend update expectations
- Added new API integration for `coffeeType`
- Cleaned up and unified status enum logic in `cropSeasonDetailStatus.ts`

BREAKING CHANGE: status is now mapped via enum instead of plain string in CropSeasonDetail
