### PR TITLE
feat(outboundrequest): implement outboudrequest UI for manager

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/page.tsx
@@ -6,6 +6,7 @@ import {
   FiPackage,
   FiBarChart2,
   FiHome,
+  FiTruck, // 🚚 Biểu tượng phù hợp cho Xuất kho
 } from 'react-icons/fi';
 import Link from 'next/link';
 import React from 'react';
@@ -35,12 +36,23 @@ export default function ManagerDashboard() {
             title="Báo cáo sản lượng"
             description="Thống kê về sản lượng, chất lượng và tiến độ."
           />
-          {/* ✅ Card có điều hướng */}
+
+          {/* ✅ Kho hàng */}
           <Link href="/dashboard/manager/warehouses">
             <DashboardCard
               icon={<FiHome className="text-orange-500 text-xl" />}
               title="Kho hàng"
               description="Quản lý danh sách kho, thêm và xoá kho mới."
+              isLink
+            />
+          </Link>
+
+          {/* ✅ Thêm nút Yêu cầu xuất kho */}
+          <Link href="/dashboard/manager/warehouse-request">
+            <DashboardCard
+              icon={<FiTruck className="text-orange-500 text-xl" />}
+              title="Yêu cầu xuất kho"
+              description="Gửi yêu cầu và theo dõi các yêu cầu xuất hàng từ kho."
               isLink
             />
           </Link>

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/warehouse-request/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/warehouse-request/page.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getAllOutboundRequests, cancelOutboundRequest } from '@/lib/api/warehouseOutboundRequest';
+import { Button } from '@/components/ui/button';
+import { useRouter } from 'next/navigation';
+
+export default function ManagerOutboundRequestList() {
+  const [data, setData] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+  getAllOutboundRequests()
+    .then((res) => {
+      if (Array.isArray(res)) {
+        setData(res); // Gán trực tiếp mảng trả về từ backend
+      } else {
+        alert('⚠️ Dữ liệu trả về không hợp lệ');
+      }
+    })
+    .catch((err) => alert('❌ Lỗi tải danh sách: ' + err.message))
+    .finally(() => setLoading(false));
+}, []);
+
+  const handleCancel = async (id: string) => {
+    const confirm = window.confirm('Bạn chắc chắn muốn hủy yêu cầu này?');
+    if (!confirm) return;
+
+    try {
+      const result = await cancelOutboundRequest(id);
+      alert('✅ ' + result.message);
+      location.reload();
+    } catch (err: any) {
+      alert('❌ ' + err.message);
+    }
+  };
+
+  if (loading) return <p>Đang tải...</p>;
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-xl font-bold">Yêu cầu xuất kho của công ty</h1>
+        <Button
+          onClick={() => router.push('/dashboard/manager/outbound-requests/create')}
+          className="bg-orange-600 text-white"
+        >
+          + Tạo yêu cầu xuất kho
+        </Button>
+      </div>
+
+      {data.length === 0 ? (
+        <p className="text-muted-foreground">Không có yêu cầu xuất kho nào.</p>
+      ) : (
+        <table className="w-full border table-auto">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="p-2 border">Mã</th>
+              <th className="p-2 border">Kho</th>
+              <th className="p-2 border">Số lượng</th>
+              <th className="p-2 border">Trạng thái</th>
+              <th className="p-2 border">Thao tác</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((item) => (
+              <tr key={item.outboundRequestId}>
+                <td className="p-2 border">{item.outboundRequestCode}</td>
+                <td className="p-2 border">{item.warehouseName}</td>
+                <td className="p-2 border">{item.requestedQuantity} {item.unit}</td>
+                <td className="p-2 border">{item.status}</td>
+                <td className="p-2 border space-x-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => router.push(`/dashboard/manager/warehouse-request/${item.outboundRequestId}`)}
+                  >
+                    Xem
+                  </Button>
+                  {item.status === 'Pending' && (
+                    <Button variant="destructive" onClick={() => handleCancel(item.outboundRequestId)}>
+                      Hủy
+                    </Button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/DakLakCoffeeSupplyChain/src/lib/api/warehouseOutboundRequest.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/warehouseOutboundRequest.ts
@@ -1,0 +1,88 @@
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
+const ENDPOINT = `${API_BASE_URL}/WarehouseOutboundRequests`;
+
+export interface CreateWarehouseOutboundRequestInput {
+  warehouseId: string;
+  inventoryId: string;
+  requestedQuantity: number;
+  unit: string;
+  purpose?: string;
+  reason?: string;
+  orderItemId?: string;
+}
+
+export async function createWarehouseOutboundRequest(
+  input: CreateWarehouseOutboundRequestInput
+): Promise<string> {
+  const token = localStorage.getItem("token");
+  if (!token) throw new Error("Chưa đăng nhập");
+
+  const response = await fetch(ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(input),
+  });
+
+  const contentType = response.headers.get("content-type");
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Lỗi server: ${errorText}`);
+  }
+
+  if (contentType?.includes("application/json")) {
+    const result = await response.json();
+    if (result.status !== 1) {
+      throw new Error(result.message || "Gửi yêu cầu thất bại");
+    }
+    return result.message;
+  }
+
+  const text = await response.text();
+  return text || "Gửi yêu cầu thành công";
+}
+
+export async function getAllOutboundRequests() {
+  const token = localStorage.getItem("token");
+  const res = await fetch(`${ENDPOINT}/all`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return await res.json();
+}
+
+export async function getOutboundRequestById(id: string) {
+  const token = localStorage.getItem("token");
+  const res = await fetch(`${ENDPOINT}/${id}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return await res.json();
+}
+
+export async function acceptOutboundRequest(id: string) {
+  const token = localStorage.getItem("token");
+  const res = await fetch(`${ENDPOINT}/${id}/accept`, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return await res.json();
+}
+
+export async function cancelOutboundRequest(id: string) {
+  const token = localStorage.getItem("token");
+  const res = await fetch(`${ENDPOINT}/${id}/cancel`, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return await res.json();
+}


### PR DESCRIPTION
☕ Feature: BusinessManager – Get All Outbound Requests
📌 Objective
Implement the UI logic for BusinessManager to view a list of outbound warehouse requests tied to their company.

✅ Main Changes
Integrated API call to GET /WarehouseOutboundRequests/all

Mapped backend response directly into table component

Added conditional UI rendering for loading, empty state, and actions

Hooked up cancel request button (only shown when status is Pending)

📁 Affected Files
app/dashboard/manager/outbound-requests/page.tsx

lib/api/warehouseOutboundRequest.ts

components/ui/button.tsx (used)

🧪 How to Test
Go to: /dashboard/manager/outbound-requests

Verify the following:

The list is correctly fetched from backend

Requests are visible only for the current manager’s company

The "Cancel" button only appears for pending requests

Navigation to detail view works

🧪 Test Cases
 ✅ Display list when backend returns data

 ❌ Show empty message if no data

 ✅ Cancel button triggers confirmation and reloads list

 ❌ Prevent cancel if request is already processed

 ✅ Button “+ Create Request” navigates correctly

🔍 Notes
Backend returns a raw array, no { status, data } wrapper — handled in FE

Uses basic Tailwind styling, will improve with shadcn UI if needed

warehouseName and unit currently are string mock/test data

🔗 Related
Module: Warehouse

Role: BusinessManager

☑️ Pre-Merge Checklist
 Verified backend returns correct data

 Checked loading/empty/error states

 Console is clean (no warnings/errors)

 Translations to be added later (currently hardcoded VN/EN)