### PR TITLE
feat(outboundrequest): implement create UI with warehouse and invento…

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/warehouse-request/create/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/warehouse-request/create/page.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+
+import { createWarehouseOutboundRequest } from '@/lib/api/warehouseOutboundRequest';
+import { getAllWarehouses } from '@/lib/api/warehouses';
+import { getInventoriesByWarehouseId } from '@/lib/api/inventory';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+
+export default function CreateOutboundRequestPage() {
+  const router = useRouter();
+
+  const [form, setForm] = useState({
+    warehouseId: '',
+    inventoryId: '',
+    requestedQuantity: '',
+    unit: '',
+    purpose: '',
+    reason: '',
+    orderItemId: '',
+  });
+
+  const [warehouses, setWarehouses] = useState<any[]>([]);
+  const [inventories, setInventories] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const isValidGuid = (value: string) =>
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(value);
+
+  // 🚚 Load danh sách kho
+  useEffect(() => {
+    const fetchWarehouses = async () => {
+      try {
+        const res = await getAllWarehouses();
+        if (res.status === 1) {
+          setWarehouses(res.data || []);
+        } else {
+          toast.error(res.message || 'Không thể tải danh sách kho');
+        }
+      } catch (err: any) {
+        toast.error(err.message || 'Lỗi khi tải kho');
+      }
+    };
+    fetchWarehouses();
+  }, []);
+
+  // 📦 Load tồn kho khi chọn kho
+  useEffect(() => {
+    if (!form.warehouseId) {
+      setInventories([]);
+      return;
+    }
+
+    const fetchInventories = async () => {
+      try {
+        const data = await getInventoriesByWarehouseId(form.warehouseId);
+        setInventories(data || []);
+      } catch (err: any) {
+        toast.error(err.message || 'Không thể tải tồn kho');
+      }
+    };
+
+    fetchInventories();
+  }, [form.warehouseId]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async () => {
+    if (!form.warehouseId || !form.inventoryId || !form.requestedQuantity || !form.unit) {
+      toast.error('Vui lòng nhập đầy đủ các trường bắt buộc');
+      return;
+    }
+
+    if (form.orderItemId && !isValidGuid(form.orderItemId)) {
+      toast.error('Order Item ID không hợp lệ (phải là GUID)');
+      return;
+    }
+
+    try {
+      setLoading(true);
+
+      const payload = {
+        warehouseId: form.warehouseId,
+        inventoryId: form.inventoryId,
+        requestedQuantity: Number(form.requestedQuantity),
+        unit: form.unit,
+        purpose: form.purpose || undefined,
+        reason: form.reason || undefined,
+        orderItemId: form.orderItemId || undefined,
+      };
+
+      const message = await createWarehouseOutboundRequest(payload);
+      toast.success(message || 'Tạo yêu cầu thành công');
+      router.push('/dashboard/manager/warehouse-request');
+    } catch (err: any) {
+      toast.error(err.message || 'Tạo yêu cầu thất bại');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6 max-w-2xl">
+      <h1 className="text-2xl font-bold">Tạo yêu cầu xuất kho</h1>
+
+      <div className="space-y-4">
+        <div>
+          <Label>Chọn kho *</Label>
+          <select
+            name="warehouseId"
+            value={form.warehouseId}
+            onChange={handleChange}
+            className="w-full p-2 border rounded"
+          >
+            <option value="">-- Chọn kho --</option>
+            {warehouses.map((w) => (
+              <option key={w.warehouseId} value={w.warehouseId}>
+                {w.name} – {w.location}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <Label>Chọn tồn kho *</Label>
+          <select
+            name="inventoryId"
+            value={form.inventoryId}
+            onChange={handleChange}
+            className="w-full p-2 border rounded"
+            disabled={!form.warehouseId}
+          >
+            <option value="">-- Chọn tồn kho --</option>
+            {inventories.map((inv) => (
+              <option key={inv.inventoryId} value={inv.inventoryId}>
+                {inv.inventoryCode} – {inv.quantity} {inv.unit}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <Label>Số lượng yêu cầu *</Label>
+          <Input
+            type="number"
+            name="requestedQuantity"
+            value={form.requestedQuantity}
+            onChange={handleChange}
+          />
+        </div>
+
+        <div>
+          <Label>Đơn vị *</Label>
+          <Input name="unit" value={form.unit} onChange={handleChange} />
+        </div>
+
+        <div>
+          <Label>Mục đích</Label>
+          <Textarea name="purpose" value={form.purpose} onChange={handleChange} />
+        </div>
+
+        <div>
+          <Label>Lý do</Label>
+          <Textarea name="reason" value={form.reason} onChange={handleChange} />
+        </div>
+
+        <div>
+          <Label>Order Item ID (test thủ công, phải là GUID)</Label>
+          <Input
+            name="orderItemId"
+            value={form.orderItemId}
+            onChange={handleChange}
+            placeholder="Nhập GUID nếu có"
+          />
+        </div>
+      </div>
+
+      <div className="flex gap-4 pt-4">
+        <Button onClick={handleSubmit} disabled={loading} className="bg-orange-600 text-white">
+          {loading ? 'Đang gửi...' : 'Tạo yêu cầu'}
+        </Button>
+        <Button variant="outline" onClick={() => router.push('/dashboard/manager/warehouse-request')}>
+          Hủy
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/warehouse-request/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/warehouse-request/page.tsx
@@ -43,7 +43,7 @@ export default function ManagerOutboundRequestList() {
       <div className="flex justify-between items-center">
         <h1 className="text-xl font-bold">Yêu cầu xuất kho của công ty</h1>
         <Button
-          onClick={() => router.push('/dashboard/manager/outbound-requests/create')}
+          onClick={() => router.push('/dashboard/manager/warehouse-request/create')}
           className="bg-orange-600 text-white"
         >
           + Tạo yêu cầu xuất kho

--- a/DakLakCoffeeSupplyChain/src/lib/api/inventory.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/inventory.ts
@@ -1,80 +1,42 @@
-const BASE_URL = "https://localhost:7163/api/Inventories";
-
-function getAuthHeaders() {
-  const token = localStorage.getItem("token");
-  return {
-    Authorization: `Bearer ${token}`,
-    "Content-Type": "application/json",
-  };
-}
+// /lib/api/inventory.ts
 
 export async function getAllInventories() {
-  try {
-    const res = await fetch(BASE_URL, {
-      headers: getAuthHeaders(),
-    });
-
-    if (!res.ok) {
-      const err = await res.text();
-      return { status: res.status, message: err, data: [] };
-    }
-
-    const data = await res.json();
-    return { status: 200, message: "OK", data };
-  } catch (err: any) {
-    return {
-      status: 500,
-      message: err.message || "Lỗi kết nối đến server",
-      data: [],
-    };
-  }
+  const token = localStorage.getItem("token");
+  const res = await fetch("https://localhost:7163/api/Inventories", {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return await res.json();
 }
 
 export async function getInventoryById(id: string) {
-  try {
-    const res = await fetch(`${BASE_URL}/${id}`, {
-      headers: getAuthHeaders(),
-    });
-
-    if (!res.ok) {
-      const err = await res.text();
-      return { status: res.status, message: err, data: null };
-    }
-
-    const data = await res.json();
-    return { status: 200, message: "OK", data };
-  } catch (err: any) {
-    return {
-      status: 500,
-      message: err.message || "Lỗi kết nối đến server",
-      data: null,
-    };
-  }
+  const token = localStorage.getItem("token");
+  const res = await fetch(`https://localhost:7163/api/Inventories/${id}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return await res.json();
 }
 
-export async function createInventory(data: {
-  warehouseId: string;
-  batchId: string;
-  quantity: number;
-}) {
-  try {
-    const res = await fetch(BASE_URL, {
-      method: "POST",
-      headers: getAuthHeaders(),
-      body: JSON.stringify(data),
-    });
+export async function getInventoriesByWarehouseId(warehouseId: string) {
+  const token = localStorage.getItem("token");
+  const res = await fetch(`https://localhost:7163/api/Inventories/warehouse/${warehouseId}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
 
-    if (!res.ok) {
-      const err = await res.text();
-      return { status: res.status, message: err };
-    }
-
-    const result = await res.json();
-    return { status: 200, message: "Tạo thành công", data: result };
-  } catch (err) {
-    return {
-      status: 500,
-      message: "Lỗi không xác định khi tạo tồn kho.",
-    };
+  if (!res.ok) {
+    const errText = await res.text();
+    throw new Error(errText || "Không lấy được tồn kho theo kho.");
   }
+
+  const contentType = res.headers.get("content-type");
+  if (!contentType?.includes("application/json")) {
+    return [];
+  }
+
+  return await res.json(); // ✅ Trả mảng tồn kho theo kho
 }

--- a/DakLakCoffeeSupplyChain/src/lib/api/warehouseOutboundRequest.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/warehouseOutboundRequest.ts
@@ -26,23 +26,14 @@ export async function createWarehouseOutboundRequest(
     body: JSON.stringify(input),
   });
 
-  const contentType = response.headers.get("content-type");
-
   if (!response.ok) {
     const errorText = await response.text();
     throw new Error(`Lỗi server: ${errorText}`);
   }
 
-  if (contentType?.includes("application/json")) {
-    const result = await response.json();
-    if (result.status !== 1) {
-      throw new Error(result.message || "Gửi yêu cầu thất bại");
-    }
-    return result.message;
-  }
-
-  const text = await response.text();
-  return text || "Gửi yêu cầu thành công";
+  // Không cần check status nữa
+  const result = await response.text();
+  return result || "Gửi yêu cầu thành công";
 }
 
 export async function getAllOutboundRequests() {


### PR DESCRIPTION
✨ Feature: [Manager] – Create Outbound Request UI
📌 Objective
Implement a UI page for BusinessManager to create a new warehouse outbound request, including selecting a warehouse, choosing available inventory, and optionally inputting an OrderItemId. This is part of the outbound warehouse flow.

✅ Main Changes
Added a create form at:
/dashboard/manager/warehouse-request/create

Allows:

Select warehouse

Load inventory list based on selected warehouse

Input requested quantity and unit

Provide optional purpose, reason, and manual OrderItemId

Form submission connects to backend via authenticated API call (Bearer token)

Error handling and success feedback via sonner toast

📁 Affected Files
app/dashboard/manager/warehouse-request/create/page.tsx

lib/api/warehouseOutboundRequest.ts

lib/api/inventory.ts (called from form)

lib/api/warehouses.ts

🧪 How to Test
Login as BusinessManager

Go to: /dashboard/manager/warehouse-request/create

Fill required fields (warehouse, inventory, quantity, unit)

(Optional) enter a valid OrderItemId GUID manually

Click “Tạo yêu cầu”

Expect:

✅ Toast on success

✅ Redirect to list

❌ Error if required fields are missing or invalid

✅ Test Cases
✅ Form renders with dynamic warehouse + inventory options

✅ Create request sends correct payload to BE

✅ OrderItemId accepted if valid GUID

❌ Rejects submission if required fields are empty

✅ Success feedback on valid request

🔍 Notes
token retrieved from localStorage

Form state managed via useState

Responsive layout for mobile and desktop

Number() is used to ensure quantity is passed as number

🔗 Related
Module: WarehouseOutboundRequests

Role: BusinessManager

Linked backend endpoint: POST /api/WarehouseOutboundRequests

☑️ Checklist (before PR)
 Manual testing complete

 Valid orderItemId tested

 No console warnings

 Commit message follows convention

