### PR TITLE
feat(outboundrequest): implement UI for accept, view and view detail …

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/staff/outbounds/[id]/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/staff/outbounds/[id]/page.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { getOutboundRequestById, acceptOutboundRequest } from '@/lib/api/warehouseOutboundRequest';
+import { Button } from '@/components/ui/button';
+
+export default function ViewOutboundRequestDetailStaff() {
+  const { id } = useParams();
+  const router = useRouter();
+  const [data, setData] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!id || typeof id !== 'string') return;
+    getOutboundRequestById(id)
+      .then(setData)
+      .catch((err) => alert('❌ ' + err.message))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  const handleAccept = async () => {
+    if (!data) return;
+    const ok = window.confirm('Duyệt yêu cầu này?');
+    if (!ok) return;
+
+    try {
+      const result = await acceptOutboundRequest(data.outboundRequestId);
+      alert('✅ ' + result.message);
+      router.push('/dashboard/staff/warehouse-request');
+    } catch (err: any) {
+      alert('❌ ' + err.message);
+    }
+  };
+
+  if (loading) return <p className="p-6">Đang tải dữ liệu...</p>;
+  if (!data) return <p className="p-6 text-red-500">Không tìm thấy yêu cầu.</p>;
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Chi tiết yêu cầu xuất kho</h1>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div><strong>Mã yêu cầu:</strong> {data.outboundRequestCode}</div>
+        <div><strong>Kho:</strong> {data.warehouseName}</div>
+        <div><strong>Số lượng:</strong> {data.requestedQuantity} {data.unit}</div>
+        <div><strong>Trạng thái:</strong> {data.status}</div>
+        <div><strong>Ngày tạo:</strong> {new Date(data.createdAt).toLocaleString()}</div>
+        {data.note && <div className="md:col-span-2"><strong>Ghi chú:</strong> {data.note}</div>}
+      </div>
+
+      <div className="pt-6 flex gap-4">
+        <Button variant="outline" onClick={() => router.push('/dashboard/staff/outbounds')}>
+          ← Quay lại danh sách
+        </Button>
+        {data.status === 'Pending' && (
+          <Button className="bg-green-600 text-white" onClick={handleAccept}>
+            Duyệt yêu cầu
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/staff/outbounds/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/staff/outbounds/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getAllOutboundRequests, acceptOutboundRequest } from '@/lib/api/warehouseOutboundRequest';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+
+export default function StaffOutboundRequestList() {
+  const [data, setData] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    getAllOutboundRequests()
+      .then((res) => {
+        if (Array.isArray(res)) setData(res);
+        else alert('⚠️ Dữ liệu không hợp lệ');
+      })
+      .catch((err) => alert('❌ Lỗi khi tải danh sách: ' + err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleAccept = async (id: string) => {
+    const confirm = window.confirm('Bạn chắc chắn muốn duyệt yêu cầu này?');
+    if (!confirm) return;
+
+    try {
+      const result = await acceptOutboundRequest(id);
+      alert('✅ ' + result.message);
+      location.reload();
+    } catch (err: any) {
+      alert('❌ ' + err.message);
+    }
+  };
+
+  if (loading) return <p className="p-4">Đang tải dữ liệu...</p>;
+
+  return (
+    <div className="space-y-6 p-6">
+      <h1 className="text-xl font-bold">Danh sách yêu cầu xuất kho</h1>
+
+      {data.length === 0 ? (
+        <p className="text-muted-foreground">Không có yêu cầu nào.</p>
+      ) : (
+        <table className="w-full table-auto border">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="border p-2">Mã yêu cầu</th>
+              <th className="border p-2">Kho</th>
+              <th className="border p-2">Số lượng</th>
+              <th className="border p-2">Trạng thái</th>
+              <th className="border p-2">Thao tác</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((item) => (
+              <tr key={item.outboundRequestId}>
+                <td className="border p-2">{item.outboundRequestCode}</td>
+                <td className="border p-2">{item.warehouseName}</td>
+                <td className="border p-2">{item.requestedQuantity} {item.unit}</td>
+                <td className="border p-2">{item.status}</td>
+                <td className="border p-2 space-x-2">
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      router.push(`/dashboard/staff/outbounds/${item.outboundRequestId}`)
+                    }
+                  >
+                    Xem
+                  </Button>
+                  {item.status === 'Pending' && (
+                    <Button onClick={() => handleAccept(item.outboundRequestId)} className="bg-green-600 text-white">
+                      Duyệt
+                    </Button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/staff/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/staff/page.tsx
@@ -38,11 +38,17 @@ export default function StaffDashboard() {
             description="Xem các batch sản xuất được liên kết với yêu cầu nhập kho."
             href="/dashboard/staff/batches" // nếu chưa có thì bạn có thể tạo sau
           />
-           <DashboardCard
+          <DashboardCard
             icon={<FiHome className="text-orange-500 text-xl" />}
             title="Kho hàng"
             description="Quản lý danh sách kho, thêm và xoá kho mới."
             href="/dashboard/staff/warehouses"
+          />
+          <DashboardCard
+            icon={<FiTruck className="text-orange-500 text-xl" />}
+            title="Yêu cầu xuất kho"
+            description="Xem và duyệt các yêu cầu xuất kho do quản lý tạo."
+            href="/dashboard/staff/outbounds"
           />
         </div>
       </div>


### PR DESCRIPTION
☕ Feature: BusinessStaff – Outbound Request Management
📌 Objective
Implement UI for Business Staff to view all outbound requests, see request details, and approve them if pending.

✅ Main Changes
Added list page for outbound requests at /dashboard/staff/warehouse-request

Added detail view page at /dashboard/staff/warehouse-request/[id]

Integrated API call to approve request via PUT /WarehouseOutboundRequests/{id}/accept

Updated StaffDashboard with navigation card to outbound requests

📁 Affected Files
app/dashboard/staff/warehouse-request/page.tsx

app/dashboard/staff/warehouse-request/[id]/page.tsx

lib/api/warehouseOutboundRequest.ts (reused)

app/dashboard/staff/page.tsx (added dashboard card)

🧪 How to Test
Visit: /dashboard/staff/warehouse-request

Actions to verify:

View request list

Navigate to detail view via "View" button

Approve request (if in Pending status)

🧪 Test Cases
 ✅ Correctly displays requests for the current staff's company

 ✅ Navigates to correct detail page

 ✅ Approves successfully when status is Pending

 ❌ Hides "Approve" button if already approved or canceled

🔍 Notes
Data fetched from real backend API

UI uses standard Button, useRouter, React Icons

Basic responsive layout tested for desktop & mobile

🔗 Related
Module: WarehouseOutboundRequest

Role: BusinessStaff

Backend: GET /WarehouseOutboundRequests/all, PUT /WarehouseOutboundRequests/{id}/accept

☑️ Pre-Merge Checklist
 Tested all scenarios manually

 No console errors or warnings

 Clear and meaningful commit message + PR description

