### PR TITLE
feat(inventory):fix display coffee type name in inventory list and de…

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/staff/inventories/[id]/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/staff/inventories/[id]/page.tsx
@@ -13,18 +13,26 @@ export default function InventoryDetailPage() {
   const [error, setError] = useState("");
 
   useEffect(() => {
-  if (id) {
-    async function fetchInventory() {
-      const res = await getInventoryById(id as string);
-      if (res.status === 200 && res.data) {
-        setInventory(res.data);
-      } else {
-        setError(res.message || "Không tìm thấy tồn kho.");
+    if (id) {
+      async function fetchInventory() {
+        try {
+          const res = await getInventoryById(id as string);
+
+          // ✅ Hỗ trợ cả ServiceResult hoặc trả thẳng object
+          if (res?.data) {
+            setInventory(res.data);
+          } else if (res?.inventoryId) {
+            setInventory(res); // fallback nếu API trả object trực tiếp
+          } else {
+            setError(res.message || "Không tìm thấy tồn kho.");
+          }
+        } catch (err: any) {
+          setError(err.message || "Lỗi khi tải dữ liệu tồn kho.");
+        }
       }
+      fetchInventory();
     }
-    fetchInventory();
-  }
-}, [id]);
+  }, [id]);
 
   if (error) return <div className="text-red-500 p-6">{error}</div>;
   if (!inventory) return <div className="p-6">Đang tải dữ liệu tồn kho...</div>;
@@ -40,8 +48,8 @@ export default function InventoryDetailPage() {
             <p><strong>Mã:</strong> {inventory.inventoryCode}</p>
             <p><strong>Kho:</strong> {inventory.warehouseName}</p>
             <p><strong>Batch:</strong> {inventory.batchCode}</p>
-            <p><strong>Sản phẩm:</strong> {inventory.productName}</p>
-            <p><strong>Loại cà phê:</strong> {inventory.coffeeTypeName}</p>
+            <p><strong>Sản phẩm:</strong> {inventory.productName || "Không có"}</p>
+            <p><strong>Loại cà phê:</strong> {inventory.coffeeTypeName || "Không xác định"}</p>
             <p><strong>Số lượng:</strong> {inventory.quantity} {inventory.unit}</p>
             <p><strong>Tạo lúc:</strong> {new Date(inventory.createdAt).toLocaleString()}</p>
             <p><strong>Cập nhật:</strong> {new Date(inventory.updatedAt).toLocaleString()}</p>

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/staff/inventories/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/staff/inventories/page.tsx
@@ -15,17 +15,31 @@ export default function InventoryListPage() {
   const [currentPage, setCurrentPage] = useState(1);
   const pageSize = 10;
 
-  useEffect(() => {
+useEffect(() => {
   async function fetchData() {
-    const res = await getAllInventories();
-    if (res.status === 200) {
-      setInventories(res.data);
-    } else {
-      alert(`❌ Lỗi: ${res.message}`);
+    try {
+      const res = await getAllInventories();
+
+      // Trường hợp trả về dạng ServiceResult
+      if (Array.isArray(res?.data)) {
+        setInventories(res.data);
+      }
+      // Trường hợp API trả thẳng mảng
+      else if (Array.isArray(res)) {
+        setInventories(res);
+      }
+      // Còn lại là lỗi
+      else {
+        alert(`❌ Lỗi: ${res.message || "Không thể lấy dữ liệu tồn kho."}`);
+      }
+    } catch (err: any) {
+      alert(`❌ Lỗi hệ thống: ${err.message}`);
     }
   }
+
   fetchData();
 }, []);
+
 
   const filtered = inventories.filter((inv) =>
     inv.inventoryCode?.toLowerCase().includes(search.toLowerCase()) ||
@@ -67,6 +81,7 @@ export default function InventoryListPage() {
                   <p className="font-semibold">Code: {inv.inventoryCode}</p>
                   <p>Warehouse: {inv.warehouseName}</p>
                   <p>Product: {inv.productName}</p>
+                  <p>Coffee Type: <span className="text-green-700 font-medium">{inv.coffeeTypeName}</span></p> {/* ✅ thêm dòng này */}
                 </div>
                 <Badge className="capitalize px-3 py-1 rounded-md font-medium text-sm bg-gray-100 text-gray-800">
                   {inv.quantity > 0 ? "Available" : "Empty"}


### PR DESCRIPTION
☕ Feature: BusinessStaff – Display Coffee Type in Inventory List & Detail Views
📌 Objective
Enhance the inventory UI for BusinessStaff by displaying the coffee type (coffeeTypeName) in both the list and detail pages. Improve robustness by handling different API response formats safely (i.e., full ServiceResult object or raw data array).

✅ Key Changes
Displayed coffeeTypeName in InventoryListPage.tsx

Added coffeeTypeName to InventoryDetailPage.tsx

Updated useEffect logic in both pages to correctly handle res.data or fallback to res directly

Added graceful fallback when coffeeTypeName is null or missing

Enhanced loading/error states for better user feedback

📁 Affected Files
app/dashboard/staff/inventories/page.tsx (list view)

app/dashboard/staff/inventories/[id]/page.tsx (detail view)

lib/api/inventory.ts

🧪 How to Test
Navigate to: /dashboard/staff/inventories

Try the following actions:

Confirm each inventory item shows Coffee Type

Click “View” to open detail page → ensure coffee type is shown

Disconnect API or token to verify error fallback works

🧪 Test Cases
 ✅ Coffee type is shown in inventory list

 ✅ Coffee type is shown in inventory detail view

 ❌ Proper error message shown if API fails

 ✅ Fallback message shown when data is missing

🔍 Notes
Used @/components/ui for layout

Applied fallback for older or partial API data

Responsive layout supported

🔗 Related
Module: Inventory

Role: BusinessStaff, BusinessManager

☑️ Checklist (before submitting PR)
 Fully tested major UI flows

 No console errors or warnings

 Clear commit message and description used