### PR TITLE
refactor(fe): allow manual input of commitmentDetailId instead of aut…

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-seasons/[id]/details/create/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-seasons/[id]/details/create/page.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { AppToast } from "@/components/ui/AppToast";
+import { getErrorMessage } from "@/lib/utils";
+import { createCropSeasonDetail } from "@/lib/api/cropSeasonDetail ";
+
+export default function CreateCropSeasonDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const cropSeasonId = params.id as string;
+
+  const [form, setForm] = useState({
+    commitmentDetailId: "",
+    areaAllocated: "",
+    plannedQuality: "",
+    expectedHarvestStart: "",
+    expectedHarvestEnd: "",
+    estimatedYield: "",
+    status: 0,
+  });
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async () => {
+    const requiredFields = [
+      "commitmentDetailId",
+      "areaAllocated",
+      "plannedQuality",
+      "expectedHarvestStart",
+      "expectedHarvestEnd",
+    ];
+    const missing = requiredFields.filter((f) => !form[f as keyof typeof form]);
+    if (missing.length > 0) {
+      AppToast.error("Vui lòng điền đầy đủ các trường bắt buộc.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await createCropSeasonDetail({
+        cropSeasonId,
+        commitmentDetailId: form.commitmentDetailId,
+        areaAllocated: parseFloat(form.areaAllocated),
+        plannedQuality: form.plannedQuality,
+        expectedHarvestStart: form.expectedHarvestStart,
+        expectedHarvestEnd: form.expectedHarvestEnd,
+        estimatedYield: parseFloat(form.estimatedYield || "0"),
+        status: Number(form.status),
+      });
+      AppToast.success("Tạo vùng trồng thành công!");
+      router.push(`/dashboard/farmer/crop-seasons/${cropSeasonId}`);
+    } catch (err) {
+      AppToast.error(getErrorMessage(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto py-10 px-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Thêm vùng trồng cho mùa vụ</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <Label>ID dòng cam kết (commitmentDetailId)</Label>
+            <Input
+              name="commitmentDetailId"
+              value={form.commitmentDetailId}
+              onChange={handleChange}
+              placeholder="Nhập ID dòng cam kết"
+              required
+            />
+          </div>
+
+          <div>
+            <Label>Diện tích (ha)</Label>
+            <Input
+              type="number"
+              name="areaAllocated"
+              value={form.areaAllocated}
+              onChange={handleChange}
+              required
+            />
+          </div>
+
+          <div>
+            <Label>Chất lượng dự kiến</Label>
+            <Input
+              name="plannedQuality"
+              value={form.plannedQuality}
+              onChange={handleChange}
+              required
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label>Bắt đầu thu hoạch</Label>
+              <Input
+                type="date"
+                name="expectedHarvestStart"
+                value={form.expectedHarvestStart}
+                onChange={handleChange}
+                required
+              />
+            </div>
+            <div>
+              <Label>Kết thúc thu hoạch</Label>
+              <Input
+                type="date"
+                name="expectedHarvestEnd"
+                value={form.expectedHarvestEnd}
+                onChange={handleChange}
+                required
+              />
+            </div>
+          </div>
+
+          <div>
+            <Label>Năng suất ước tính (tấn)</Label>
+            <Input
+              type="number"
+              name="estimatedYield"
+              value={form.estimatedYield}
+              onChange={handleChange}
+            />
+          </div>
+
+          <div className="flex justify-end">
+            <Button onClick={handleSubmit} disabled={isSubmitting}>
+              {isSubmitting ? "Đang tạo..." : "Tạo vùng trồng"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-seasons/[id]/details/edit/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-seasons/[id]/details/edit/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { getCoffeeTypes, CoffeeType } from "@/lib/api/coffeeType";
 import { AppToast } from "@/components/ui/AppToast";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -32,7 +31,7 @@ export default function UpdateCropSeasonDetailDialog({
   onSuccess,
 }: Props) {
   const [form, setForm] = useState({
-    coffeeTypeId: "",
+    commitmentDetailId: "",
     areaAllocated: "",
     plannedQuality: "",
     expectedHarvestStart: "",
@@ -41,22 +40,16 @@ export default function UpdateCropSeasonDetailDialog({
     status: "Planned" as CropSeasonDetailStatusValue,
   });
 
-  const [coffeeTypes, setCoffeeTypes] = useState<CoffeeType[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const [types, detail] = await Promise.all([
-          getCoffeeTypes(),
-          getCropSeasonDetailById(detailId),
-        ]);
-
-        setCoffeeTypes(types);
+        const detail = await getCropSeasonDetailById(detailId);
 
         setForm({
-          coffeeTypeId: detail.coffeeTypeId,
+          commitmentDetailId: detail.commitmentDetailId,
           areaAllocated: detail.areaAllocated?.toString() || "",
           plannedQuality: detail.plannedQuality || "",
           expectedHarvestStart: detail.expectedHarvestStart,
@@ -86,7 +79,7 @@ export default function UpdateCropSeasonDetailDialog({
 
   const handleSubmit = async () => {
     const {
-      coffeeTypeId,
+      commitmentDetailId,
       areaAllocated,
       plannedQuality,
       expectedHarvestStart,
@@ -99,7 +92,7 @@ export default function UpdateCropSeasonDetailDialog({
 
     const payload = {
       detailId,
-      coffeeTypeId,
+      commitmentDetailId,
       expectedHarvestStart,
       expectedHarvestEnd,
       estimatedYield: parseFloat(estimatedYield || "0"),
@@ -126,20 +119,14 @@ export default function UpdateCropSeasonDetailDialog({
   return (
     <div className="space-y-4">
       <div>
-        <Label>Loại cà phê</Label>
-        <select
-          name="coffeeTypeId"
-          value={form.coffeeTypeId}
+        <Label>ID dòng cam kết (commitmentDetailId)</Label>
+        <Input
+          name="commitmentDetailId"
+          value={form.commitmentDetailId}
           onChange={handleChange}
-          className="w-full border rounded px-2 py-2"
-        >
-          <option value="">-- Chọn loại cà phê --</option>
-          {coffeeTypes.map((type) => (
-            <option key={type.coffeeTypeId} value={type.coffeeTypeId}>
-              {type.typeName}
-            </option>
-          ))}
-        </select>
+          placeholder="Nhập ID dòng cam kết"
+          required
+        />
       </div>
 
       <div>

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-seasons/[id]/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-seasons/[id]/page.tsx
@@ -125,6 +125,16 @@ export default function CropSeasonDetail() {
                 <Card>
                     <CardHeader className="flex justify-between items-center">
                         <CardTitle>Chi tiết vùng trồng</CardTitle>
+                        {user?.role === 'farmer' && (
+                            <Button
+                                size="sm"
+                                onClick={() =>
+                                    router.push(`/dashboard/farmer/crop-seasons/${season.cropSeasonId}/details/create`)
+                                }
+                            >
+                                + Thêm vùng trồng
+                            </Button>
+                        )}
                     </CardHeader>
                     <CardContent>
                         <CropSeasonDetailTable

--- a/DakLakCoffeeSupplyChain/src/lib/api/cropSeasonDetail .ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/cropSeasonDetail .ts
@@ -2,14 +2,13 @@ import api from '@/lib/api/axios';
 import { getErrorMessage } from '@/lib/utils';
 
 // ================== TYPES ==================
-// ================== TYPES ==================
 
 export type CropSeasonDetail = {
   success: any;
   error: string;
   detailId: string;
   cropSeasonId: string;
-  coffeeTypeId: string;
+  commitmentDetailId: string; // ✅ Dùng thay cho coffeeTypeId
   expectedHarvestStart: string;
   expectedHarvestEnd: string;
   estimatedYield: number;
@@ -22,23 +21,29 @@ export type CropSeasonDetail = {
   farmerName: string;
 };
 
-export type CropSeasonDetailCreatePayload = Omit<
-  CropSeasonDetail,
-  'detailId' | 'farmerId' | 'farmerName' | 'qualityGrade' | 'actualYield'
->;
+// ✅ Tạo vùng trồng – sử dụng commitmentDetailId thay cho coffeeTypeId
+export type CropSeasonDetailCreatePayload = {
+  cropSeasonId: string;
+  commitmentDetailId: string;
+  expectedHarvestStart: string;
+  expectedHarvestEnd: string;
+  estimatedYield: number;
+  areaAllocated: number;
+  plannedQuality: string;
+  status: number;
+};
 
-// ✅ Cập nhật lại chuẩn payload update
+// ✅ Cập nhật vùng trồng – không thay đổi
 export type CropSeasonDetailUpdatePayload = {
-  detailId: string;               // ✅ Required
-  coffeeTypeId: string;           // ✅ Required
-  expectedHarvestStart?: string; // gửi đúng định dạng yyyy-MM-dd
+  detailId: string;
+  commitmentDetailId?: string; // optional nếu không đổi dòng cam kết
+  expectedHarvestStart?: string;
   expectedHarvestEnd?: string;
   estimatedYield?: number;
   areaAllocated?: number;
   plannedQuality?: string;
-  status: number;                 // enum int
+  status: number;
 };
-
 
 // ================== API FUNCTIONS ==================
 


### PR DESCRIPTION
## ☕ Tính năng: [Farmer] – Nhập ID dòng cam kết thủ công

---

### 📌 Mục tiêu  
Cập nhật giao diện tạo và chỉnh sửa vùng trồng (`CropSeasonDetail`) để người dùng có thể **nhập tay `commitmentDetailId`** từ bàn phím, tạm thời thay cho việc chọn từ dropdown tự động (do dữ liệu cam kết chưa sẵn sàng ở luồng 1).

---

### ✅ Thay đổi chính  
- Thay `select` dropdown thành `Input` để nhập `commitmentDetailId`  
- Gỡ bỏ toàn bộ logic fetch danh sách dòng cam kết (`getAvailableCommitments`)  
- Refactor payload gửi lên API để dùng `commitmentDetailId`  
- Hiển thị placeholder rõ ràng cho người dùng dễ thử nghiệm

---

### 📁 File ảnh hưởng  
- `src/app/dashboard/farmer/crop-seasons/[id]/details/create/page.tsx`  
- `src/app/dashboard/farmer/crop-seasons/[id]/details/edit/page.tsx`  
- `src/app/dashboard/farmer/crop-seasons/[id]/page.tsx`  
- `src/lib/api/cropSeasonDetail .ts`

---

### 🧪 Cách kiểm tra  
1. Truy cập trang:
   - `/dashboard/farmer/crop-seasons/[id]/details/create`
   - `/dashboard/farmer/crop-seasons/[id]/details/edit`
2. Thử nhập 1 `commitmentDetailId` hợp lệ (có thể mock UUID)
3. Gửi form và kiểm tra dữ liệu được tạo hoặc cập nhật

---

### 🧪 Test Case
- [x] ✅ Tạo vùng trồng mới khi nhập `commitmentDetailId` hợp lệ
- [x] ❌ Hiển thị lỗi nếu thiếu trường bắt buộc
- [x] ✅ Cập nhật vùng trồng thành công khi sửa dữ liệu

---

### 🔍 Ghi chú
- Tạm thời không phụ thuộc API cam kết từ luồng 1
- Sau này có thể thay lại bằng dropdown khi có DTO phù hợp

---

### 🔗 Liên quan
- Module: `Farmer > CropSeasonDetail`
- Role: `Farmer`
- Issue: `#80`

---

### ☑️ Checklist (trước khi tạo PR)
- [x] Đã test đầy đủ các case
- [x] Đã kiểm tra lỗi console / warning
- [x] Đã dùng ngôn ngữ rõ ràng trong commit & description
