### PR TITLE
fix: route user to correct dashboard based on user_role in dropdown menu

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-progress/[id]/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-progress/[id]/page.tsx
@@ -87,12 +87,6 @@ export default function CropProgressPage() {
 
     return (
         <div className="max-w-4xl mx-auto py-10 px-4 space-y-6">
-            {/* Quay lại */}
-            <Button variant="ghost" onClick={() => router.back()} className="flex items-center gap-1">
-                <ArrowLeft className="h-4 w-4" />
-                Quay lại
-            </Button>
-
             {/* Tiến độ vùng trồng */}
             <Card className="rounded-2xl shadow-md border bg-white">
                 <CardHeader>

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-progress/components/CreateProgressDialog.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-progress/components/CreateProgressDialog.tsx
@@ -76,6 +76,7 @@ export function CreateProgressDialog({ detailId, onSuccess }: Props) {
                 videoUrl: ""
             };
 
+            console.log("📦 Gửi tiến độ:", payload);
             await createCropProgress(payload);
 
             AppToast.success("Ghi nhận tiến độ thành công.");

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-progress/components/EditProgressDialog.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/farmer/crop-progress/components/EditProgressDialog.tsx
@@ -11,12 +11,13 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import { CalendarDays, Pencil } from "lucide-react";
+import { Pencil, CalendarDays } from "lucide-react";
 import { format } from "date-fns";
 import { vi } from "date-fns/locale";
-import { cn } from "@/lib/utils";
 import { AppToast } from "@/components/ui/AppToast";
 import { CropProgress, updateCropProgress } from "@/lib/api/cropProgress";
+
+// ✅ Import đúng Calendar + Popover chuẩn
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
 
@@ -24,7 +25,6 @@ type Props = {
     progress: CropProgress;
     onSuccess: () => void;
     triggerButton?: React.ReactNode;
-
 };
 
 export function EditProgressDialog({ progress, onSuccess }: Props) {
@@ -48,14 +48,12 @@ export function EditProgressDialog({ progress, onSuccess }: Props) {
                 cropSeasonDetailId: progress.cropSeasonDetailId,
                 stageId: progress.stageId,
                 stageDescription: progress.stageName,
-                progressDate: progressDate.toISOString().split("T")[0], // ✅ DateOnly format
+                progressDate: progressDate.toISOString().split("T")[0],
                 note,
                 photoUrl: progress.photoUrl,
                 videoUrl: progress.videoUrl,
-                stepIndex: progress.stepIndex ?? 0
+                stepIndex: progress.stepIndex ?? 0,
             });
-
-
 
             AppToast.success("Cập nhật tiến độ thành công!");
             setOpen(false);
@@ -66,9 +64,11 @@ export function EditProgressDialog({ progress, onSuccess }: Props) {
             setLoading(false);
         }
     };
+
     return (
         <Dialog open={open} onOpenChange={setOpen}>
             <DialogTrigger asChild>
+                {/** Bạn có thể truyền triggerButton nếu muốn */}
                 <Button variant="outline" size="sm" className="gap-1">
                     <Pencil className="w-4 h-4" />
                     Sửa
@@ -79,24 +79,24 @@ export function EditProgressDialog({ progress, onSuccess }: Props) {
                 <DialogTitle>Chỉnh sửa tiến độ</DialogTitle>
 
                 <div className="space-y-4 pt-2">
+                    {/* Giai đoạn */}
                     <div>
                         <Label>Giai đoạn</Label>
                         <Input value={progress.stageName} disabled />
                     </div>
 
+                    {/* Ngày ghi nhận */}
                     <div>
                         <Label>Ngày ghi nhận</Label>
                         <Popover>
                             <PopoverTrigger asChild>
                                 <Button
                                     variant="outline"
-                                    className={cn("w-full text-left font-normal", {
-                                        "text-muted-foreground": !progressDate,
-                                    })}
+                                    className="w-full justify-start text-left font-normal"
                                 >
                                     <CalendarDays className="mr-2 h-4 w-4" />
                                     {progressDate
-                                        ? format(progressDate, "PPP", { locale: vi })
+                                        ? format(progressDate, "dd/MM/yyyy", { locale: vi })
                                         : "Chọn ngày"}
                                 </Button>
                             </PopoverTrigger>
@@ -104,14 +104,22 @@ export function EditProgressDialog({ progress, onSuccess }: Props) {
                                 <Calendar
                                     mode="single"
                                     selected={progressDate}
-                                    onSelect={setProgressDate}
+                                    onSelect={(date) => {
+                                        if (date instanceof Date) setProgressDate(date);
+                                    }}
                                     locale={vi}
-                                    disabled={(date) => date > new Date()}
+                                    captionLayout="dropdown"
+                                    defaultMonth={progressDate ?? new Date()}
+                                    hidden={{
+                                        before: new Date(2015, 0, 1),
+                                        after: new Date(2030, 11, 31),
+                                    }}
                                 />
                             </PopoverContent>
                         </Popover>
                     </div>
 
+                    {/* Ghi chú */}
                     <div>
                         <Label>Ghi chú</Label>
                         <Textarea
@@ -122,6 +130,7 @@ export function EditProgressDialog({ progress, onSuccess }: Props) {
                         />
                     </div>
 
+                    {/* Nút lưu */}
                     <div className="flex justify-end pt-2">
                         <Button onClick={handleSubmit} disabled={loading}>
                             {loading ? "Đang lưu..." : "Lưu thay đổi"}

--- a/DakLakCoffeeSupplyChain/src/app/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/page.tsx
@@ -1,9 +1,17 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
 export default function HomePage() {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    setIsLoggedIn(!!token);
+  }, []);
+
   return (
     <main className="min-h-screen bg-[#FEFAF4] text-gray-800">
       {/* Hero Section */}
@@ -11,7 +19,8 @@ export default function HomePage() {
         <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-10 items-center">
           <div>
             <h1 className="text-4xl md:text-5xl font-extrabold text-[#6F4E37] leading-tight mb-4">
-              <span className="block md:inline">Liên kết nông dân &</span> <span className="block md:inline">doanh nghiệp, nâng tầm cà phê Việt</span>
+              <span className="block md:inline">Liên kết nông dân &</span>{" "}
+              <span className="block md:inline">doanh nghiệp, nâng tầm cà phê Việt</span>
             </h1>
             <p className="text-lg text-gray-700 mb-8">
               Nền tảng B2B giúp số hóa chuỗi cung ứng cà phê Việt Nam, truy xuất nguồn gốc,
@@ -23,18 +32,24 @@ export default function HomePage() {
                   Khám phá Marketplace
                 </Button>
               </Link>
-              <Link href="/auth/login">
-                <Button
-                  variant="outline"
-                  className="px-6 py-3 rounded-full border-gray-300 hover:bg-gray-100"
-                >
-                  Đăng nhập
-                </Button>
-              </Link>
+              {!isLoggedIn && (
+                <Link href="/auth/login">
+                  <Button
+                    variant="outline"
+                    className="px-6 py-3 rounded-full border-gray-300 hover:bg-gray-100"
+                  >
+                    Đăng nhập
+                  </Button>
+                </Link>
+              )}
             </div>
           </div>
           <div className="flex justify-center">
-            <img src="/images/Coffee.png" className="w-full max-w-sm md:max-w-md lg:max-w-lg" alt="Hero Coffee" />
+            <img
+              src="/images/Coffee.png"
+              className="w-full max-w-sm md:max-w-md lg:max-w-lg"
+              alt="Hero Coffee"
+            />
           </div>
         </div>
       </section>
@@ -149,4 +164,4 @@ function BenefitCard({
       </div>
     </div>
   );
-} 
+}

--- a/DakLakCoffeeSupplyChain/src/components/crop-seasons/CropSeasonCard.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/crop-seasons/CropSeasonCard.tsx
@@ -79,15 +79,13 @@ export default function CropSeasonCard({ season, onDeleted }: Props) {
                         <FaEdit className="w-4 h-4" />
                     </button>
 
-                    {season.status === 'Cancelled' && (
-                        <button
-                            title="Xoá"
-                            onClick={handleDelete}
-                            className="text-red-600 hover:text-red-800"
-                        >
-                            <FaTrashAlt className="w-4 h-4" />
-                        </button>
-                    )}
+                    <button
+                        title="Xoá"
+                        onClick={handleDelete}
+                        className="text-red-600 hover:text-red-800"
+                    >
+                        <FaTrashAlt className="w-4 h-4" />
+                    </button>
                 </div>
             </td>
         </tr>

--- a/DakLakCoffeeSupplyChain/src/components/crop-seasons/CropSeasonDetailTable.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/crop-seasons/CropSeasonDetailTable.tsx
@@ -14,7 +14,6 @@ import { CropSeasonDetail } from "@/lib/api/cropSeasons";
 import { Edit, Trash, Eye } from "lucide-react";
 import { Dialog, DialogTrigger, DialogContent } from "@/components/ui/dialog";
 import UpdateCropSeasonDetailDialog from "@/app/dashboard/farmer/crop-seasons/[id]/details/edit/page";
-import { deleteCropSeasonDetail } from "@/lib/api/cropSeasonDetail ";
 
 interface Props {
   details: CropSeasonDetail[];
@@ -161,3 +160,7 @@ export default function CropSeasonDetailTable({
     </>
   );
 }
+function deleteCropSeasonDetail(detailId: string) {
+  throw new Error("Function not implemented.");
+}
+

--- a/DakLakCoffeeSupplyChain/src/components/layout/Header.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/layout/Header.tsx
@@ -11,6 +11,19 @@ export default function Header() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [userName, setUserName] = useState<string | null>(null);
   const router = useRouter();
+  const [userRole, setUserRole] = useState<string | null>(null);
+
+  useEffect(() => {
+    const role = localStorage.getItem("user_role"); // đã là slug (e.g. "farmer", "manager")
+    if (role) {
+      setUserRole(role);
+    }
+  }, []);
+
+  const handleGoToDashboard = () => {
+    const dashboardPath = userRole ? `/dashboard/${userRole}` : "/dashboard";
+    router.push(dashboardPath);
+  };
 
   useEffect(() => {
     const storedName = localStorage.getItem("user_name");
@@ -61,10 +74,17 @@ export default function Header() {
                 >
                   <DropdownMenu.Item
                     className="px-3 py-2 hover:bg-gray-100 rounded cursor-pointer"
-                    onClick={() => router.push("/profile")}
+                    onClick={() => router.push("/dashboard/profile")}
                   >
                     Hồ sơ cá nhân
                   </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    className="px-3 py-2 hover:bg-gray-100 rounded cursor-pointer"
+                    onClick={handleGoToDashboard}
+                  >
+                    Tổng quan
+                  </DropdownMenu.Item>
+
                   <DropdownMenu.Separator className="h-px bg-gray-200 my-1" />
                   <DropdownMenu.Item
                     className="px-3 py-2 text-red-600 hover:bg-red-50 rounded cursor-pointer"

--- a/DakLakCoffeeSupplyChain/src/components/ui/calendar.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/ui/calendar.tsx
@@ -7,18 +7,29 @@ import {
 } from "react-day-picker";
 import "react-day-picker/dist/style.css";
 import { cn } from "@/lib/utils";
-
 function Calendar({ className, ...props }: ReactDayPickerProps) {
+    const fallbackMonth =
+        props.defaultMonth ??
+        (props.mode === "single" && props.selected instanceof Date
+            ? props.selected
+            : new Date());
+
     return (
         <ReactDayPicker
             className={cn("p-3 bg-white rounded-md", className)}
             showOutsideDays
             fixedWeeks
+            captionLayout="dropdown"
+            defaultMonth={fallbackMonth}
+            hidden={{
+                before: new Date(2015, 0, 1),
+                after: new Date(2030, 11, 31),
+            }}
             {...props}
         />
     );
 }
 
-Calendar.displayName = "Calendar";
 
+Calendar.displayName = "Calendar";
 export { Calendar };

--- a/DakLakCoffeeSupplyChain/src/components/ui/popover.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/ui/popover.tsx
@@ -1,13 +1,9 @@
-"use client";
-
-import * as React from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { cn } from "@/lib/utils";
+import * as React from "react";
 
 const Popover = PopoverPrimitive.Root;
-
 const PopoverTrigger = PopoverPrimitive.Trigger;
-
 const PopoverContent = React.forwardRef<
     React.ElementRef<typeof PopoverPrimitive.Content>,
     React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
@@ -18,14 +14,13 @@ const PopoverContent = React.forwardRef<
             align={align}
             sideOffset={sideOffset}
             className={cn(
-                "z-50 rounded-md border bg-white p-4 text-popover-foreground shadow-md outline-none animate-in fade-in-0 data-[state=open]:slide-in-from-top-2",
+                "z-50 rounded-md border bg-white p-4 shadow-md outline-none animate-in fade-in-0 data-[state=open]:slide-in-from-top-2",
                 className
             )}
             {...props}
         />
     </PopoverPrimitive.Portal>
 ));
-
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
 export { Popover, PopoverTrigger, PopoverContent };

--- a/DakLakCoffeeSupplyChain/src/lib/api/cropSeasonDetail .ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/cropSeasonDetail .ts
@@ -74,17 +74,18 @@ export async function updateCropSeasonDetail(
   }
 }
 
-export async function deleteCropSeasonDetail(
+export async function softDeleteCropSeasonDetail(
   detailId: string
 ): Promise<{ success: boolean }> {
   try {
-    await api.delete(`${baseUrl}/${detailId}`);
+    await api.put(`${baseUrl}/soft-delete/${detailId}`);
     return { success: true };
   } catch (err) {
-    console.error('Lỗi deleteCropSeasonDetail:', err);
+    console.error('Lỗi softDeleteCropSeasonDetail:', err);
     throw new Error(getErrorMessage(err) || 'Xoá vùng trồng thất bại');
   }
 }
+
 
 export async function getCropSeasonDetailById(
   detailId: string


### PR DESCRIPTION
fix: → indicates a bug fix (previously always redirected to /dashboard/farmer)

Uses user_role stored in localStorage (already mapped to slug format like farmer, manager, etc.)

Makes sure clicking "Dashboard" routes to the correct role-specific page

