### PR TITLE
feat(outbound-request): add reject action with reason input and detai…

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/warehouse-request/[id]/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/warehouse-request/[id]/page.tsx
@@ -86,7 +86,6 @@ export default function ViewOutboundRequestDetail() {
       <h1 className="text-2xl font-bold">Chi tiết yêu cầu xuất kho</h1>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm">
-        {/* Thông tin kho & hàng */}
         <div><strong>Mã yêu cầu:</strong> {data.outboundRequestCode || 'Không rõ'}</div>
         <div><strong>Kho:</strong> {data.warehouseName || 'Không rõ'}</div>
 
@@ -108,6 +107,12 @@ export default function ViewOutboundRequestDetail() {
 
         <div><strong>Ngày tạo:</strong> {formatDate(data.createdAt)}</div>
         <div><strong>Ngày cập nhật:</strong> {formatDate(data.updatedAt)}</div>
+
+        {data.status === 'Rejected' && (
+          <div className="md:col-span-2 text-red-600">
+            <strong>Lý do từ chối:</strong> {data.reason || 'Không có'}
+          </div>
+        )}
       </div>
 
       <div className="pt-6 flex gap-4">

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/staff/outbounds/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/staff/outbounds/page.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { getAllOutboundRequests, acceptOutboundRequest } from '@/lib/api/warehouseOutboundRequest';
+import {
+  getAllOutboundRequests,
+  acceptOutboundRequest,
+  rejectOutboundRequest,
+} from '@/lib/api/warehouseOutboundRequest';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -41,6 +45,32 @@ export default function StaffOutboundRequestList() {
     }
   };
 
+ const handleReject = async (id: string) => {
+  const reason = prompt('Nhập lý do từ chối yêu cầu:');
+  if (!reason || !reason.trim()) return;
+
+  try {
+    const result = await rejectOutboundRequest(id, reason);
+    if (result.status === 1) {
+      alert('✅ ' + result.message);
+
+      // 🧠 Cập nhật lại trạng thái và rejectReason cho item tương ứng
+      setData((prev) =>
+        prev.map((item) =>
+          item.outboundRequestId === id
+            ? { ...item, status: 'Rejected', rejectReason: reason }
+            : item
+        )
+      );
+    } else {
+      alert('❌ ' + result.message);
+    }
+  } catch (err: any) {
+    alert('❌ ' + err.message);
+  }
+};
+
+
   const getStatusBadge = (status: string) => {
     switch (status) {
       case 'Pending':
@@ -51,6 +81,8 @@ export default function StaffOutboundRequestList() {
         return <Badge className="bg-green-100 text-green-800">✅ Hoàn tất</Badge>;
       case 'Cancelled':
         return <Badge className="bg-yellow-100 text-yellow-800">🚫 Đã huỷ</Badge>;
+      case 'Rejected':
+        return <Badge className="bg-red-100 text-red-800">❌ Từ chối</Badge>;
       default:
         return <Badge>{status}</Badge>;
     }
@@ -94,12 +126,20 @@ export default function StaffOutboundRequestList() {
                         Xem
                       </Button>
                       {item.status === 'Pending' && (
-                        <Button
-                          onClick={() => handleAccept(item.outboundRequestId)}
-                          className="bg-green-600 text-white"
-                        >
-                          Duyệt
-                        </Button>
+                        <>
+                          <Button
+                            onClick={() => handleAccept(item.outboundRequestId)}
+                            className="bg-green-600 text-white"
+                          >
+                            Duyệt
+                          </Button>
+                          <Button
+                            onClick={() => handleReject(item.outboundRequestId)}
+                            className="bg-red-600 text-white"
+                          >
+                            Từ chối
+                          </Button>
+                        </>
                       )}
                     </td>
                   </tr>

--- a/DakLakCoffeeSupplyChain/src/lib/api/warehouseOutboundRequest.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/warehouseOutboundRequest.ts
@@ -92,3 +92,16 @@ export async function cancelOutboundRequest(id: string): Promise<ServiceResult<a
 
   return await res.json();
 }
+export async function rejectOutboundRequest(id: string, reason: string): Promise<ServiceResult<any>> {
+  const token = getToken();
+  const res = await fetch(`${ENDPOINT}/${id}/reject`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ rejectReason: reason }),
+  });
+
+  return await res.json();
+}


### PR DESCRIPTION
☕ Feature: Reject Outbound Request (Frontend)
📌 Objective
Allow staff users to reject pending outbound requests with a reason prompt.
Rejected reason is sent to backend and displayed in detail view for managers.

✅ Key Changes
Add "Reject" button in staff outbound request list (table action buttons)

Prompt input for rejection reason using window.prompt()

Send reject request via rejectOutboundRequest(id, reason) API

Update request list state locally after rejection

Update manager detail view (ViewOutboundRequestDetail) to show reason if request is rejected

🧱 Affected Files
StaffOutboundRequestList.tsx

warehouseOutboundRequest.ts (API client)

ViewOutboundRequestDetail.tsx

📁 Added
None (reused existing components)

🛠️ How to Test
Login as BusinessStaff, go to StaffOutboundRequestList

Choose a Pending request → click "Reject"

Enter reason → see confirmation alert → row status becomes "Rejected"

Login as BusinessManager, open detail view of rejected request → check "Rejection Reason" is displayed

🧪 Test Cases
 ✅ Reject request with valid reason → updates status, shows reason in detail

 ❌ Submit empty reason → action is cancelled

 ❌ Reject non-pending request → button not shown

 ✅ Reject multiple requests → all update correctly

🔍 Notes
No modal used for reason input (simple prompt used for now)

Rejection reason is stored in reason field (shared with manager’s optional field)

Works without changing database schema

🔗 Related
Modules: WarehouseOutboundRequest, Staff Dashboard

Roles: BusinessStaff, BusinessManager