### PR TITLE
feat(manager-dashboard): update sidebar and dashboard UI with 'Hợp đồng cung ứng' and 'Kế hoạch thu mua' cards

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import {
   FiFileText,
@@ -7,21 +7,33 @@ import {
   FiBarChart2,
   FiHome,
   FiTruck,
-  FiClock, // 🚚 Biểu tượng phù hợp cho Xuất kho
-} from 'react-icons/fi';
-import Link from 'next/link';
-import React from 'react';
+  FiClock, // Biểu tượng phù hợp cho Xuất kho
+  FiClipboard,
+} from "react-icons/fi";
+import Link from "next/link";
+import React from "react";
 
 export default function ManagerDashboard() {
   return (
     <div className="w-full bg-orange-50 min-h-screen">
       <div className="p-6">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <DashboardCard
-            icon={<FiFileText className="text-orange-500 text-xl" />}
-            title="Hợp đồng thu mua"
-            description="Theo dõi và quản lý các hợp đồng với nông hộ và doanh nghiệp."
-          />
+          <Link href="/dashboard/manager/contracts">
+            <DashboardCard
+              icon={<FiFileText className="text-orange-500 text-xl" />}
+              title="Hợp đồng cung ứng"
+              description="Quản lý các hợp đồng bán hàng ký kết với doanh nghiệp."
+              isLink
+            />
+          </Link>
+          <Link href="/dashboard/manager/procurement-plans">
+            <DashboardCard
+              icon={<FiClipboard className="text-orange-500 text-xl" />}
+              title="Kế hoạch thu mua"
+              description="Tạo và theo dõi kế hoạch thu mua từ nông dân để đáp ứng hợp đồng cung ứng."
+              isLink
+            />
+          </Link>
           <DashboardCard
             icon={<FiUsers className="text-orange-500 text-xl" />}
             title="Danh sách nông dân"
@@ -38,7 +50,7 @@ export default function ManagerDashboard() {
             description="Thống kê về sản lượng, chất lượng và tiến độ."
           />
 
-          {/* ✅ Kho hàng */}
+          {/* Kho hàng */}
           <Link href="/dashboard/manager/warehouses">
             <DashboardCard
               icon={<FiHome className="text-orange-500 text-xl" />}
@@ -48,7 +60,7 @@ export default function ManagerDashboard() {
             />
           </Link>
 
-          {/* ✅ Thêm nút Yêu cầu xuất kho */}
+          {/* Thêm nút Yêu cầu xuất kho */}
           <Link href="/dashboard/manager/warehouse-request">
             <DashboardCard
               icon={<FiTruck className="text-orange-500 text-xl" />}
@@ -57,16 +69,16 @@ export default function ManagerDashboard() {
               isLink
             />
           </Link>
-          {/* ✅ Tồn kho (Inventory) */}
+          {/* Tồn kho (Inventory) */}
           <Link href="/dashboard/manager/inventories">
             <DashboardCard
-              icon={<FiPackage className="text-orange-500 text-xl" />} // 📦 dùng icon cũ cho nhất quán
+              icon={<FiPackage className="text-orange-500 text-xl" />} // dùng icon cũ cho nhất quán
               title="Tồn kho"
               description="Xem danh sách hàng tồn trong các kho do bạn quản lý."
               isLink
             />
           </Link>
-          {/* ✅ Lịch sử tồn kho */}
+          {/* Lịch sử tồn kho */}
           <Link href="/dashboard/manager/inventory-logs">
             <DashboardCard
               icon={<FiClock className="text-orange-500 text-xl" />}
@@ -75,7 +87,7 @@ export default function ManagerDashboard() {
               isLink
             />
           </Link>
-          {/* ✅ Quản lý nhân viên (BusinessStaffs) */}
+          {/* Quản lý nhân viên (BusinessStaffs) */}
           <Link href="/dashboard/manager/business-staffs">
             <DashboardCard
               icon={<FiUsers className="text-orange-500 text-xl" />}
@@ -104,7 +116,7 @@ function DashboardCard({
   return (
     <div
       className={`p-5 bg-white rounded-xl shadow-md hover:shadow-lg transition ${
-        isLink ? 'cursor-pointer' : ''
+        isLink ? "cursor-pointer" : ""
       }`}
     >
       <div className="flex items-center gap-3 mb-2">

--- a/DakLakCoffeeSupplyChain/src/components/ui/sidebar.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/ui/sidebar.tsx
@@ -18,6 +18,9 @@ import {
   FiFeather,
   FiTruck,
   FiChevronDown,
+  FiPackage,
+  FiCalendar,
+  FiShoppingCart,
 } from "react-icons/fi";
 
 const iconMap = {
@@ -226,7 +229,6 @@ export function SidebarGroup() {
       //   href: "/dashboard/staff/outbound-receipts",
       //   icon: <FiFileText />,
       // },
-
     ],
     manager: [
       {
@@ -235,9 +237,14 @@ export function SidebarGroup() {
         icon: iconMap.dashboard,
       },
       {
-        title: "Hợp đồng",
+        title: "Hợp đồng cung ứng",
         href: "/dashboard/manager/contracts",
         icon: iconMap.contracts,
+      },
+      {
+        title: "Lịch giao hàng",
+        href: "/dashboard/manager/contract-deliveries",
+        icon: <FiCalendar />,
       },
       {
         title: "Kế hoạch thu mua",
@@ -248,6 +255,26 @@ export function SidebarGroup() {
         title: "Cam kết với nông dân",
         href: "/dashboard/manager/farming-commitments",
         icon: iconMap.contracts,
+      },
+      {
+        title: "Đơn hàng",
+        href: "/dashboard/manager/orders",
+        icon: <FiShoppingCart />,
+      },
+      {
+        title: "Lô giao hàng",
+        href: "/dashboard/manager/shipments",
+        icon: <FiTruck />,
+      },
+      {
+        title: "Khách hàng doanh nghiệp",
+        href: "/dashboard/manager/business-buyers",
+        icon: <FiUsers />,
+      },
+      {
+        title: "Sản phẩm",
+        href: "/dashboard/manager/products",
+        icon: <FiPackage />,
       },
       {
         title: "Nông dân",
@@ -274,7 +301,6 @@ export function SidebarGroup() {
         href: "/dashboard/manager/warehouse-request",
         icon: <FiClipboard />,
       },
-
     ],
   };
 
@@ -444,68 +470,100 @@ export function SidebarGroup() {
           </button>
           {processingOpen && (
             <div className="pl-8 space-y-1">
-              <Link href="/dashboard/manager/processing/batches" className={cn(
-                "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
-                pathname === "/dashboard/manager/processing/batches"
-                  ? "bg-orange-100 text-orange-700"
-                  : "text-gray-600 hover:bg-orange-50 hover:text-orange-600"
-              )}>
+              <Link
+                href="/dashboard/manager/processing/batches"
+                className={cn(
+                  "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                  pathname === "/dashboard/manager/processing/batches"
+                    ? "bg-orange-100 text-orange-700"
+                    : "text-gray-600 hover:bg-orange-50 hover:text-orange-600"
+                )}
+              >
                 Danh sách lô chế biến
               </Link>
-              <Link href="/dashboard/manager/processing/evaluations" className={cn(
-                "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
-                pathname.startsWith("/dashboard/manager/processing/evaluations")
-                  ? "bg-orange-100 text-orange-700"
-                  : "text-gray-600 hover:bg-orange-50 hover:text-orange-600"
-              )}>
+              <Link
+                href="/dashboard/manager/processing/evaluations"
+                className={cn(
+                  "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                  pathname.startsWith(
+                    "/dashboard/manager/processing/evaluations"
+                  )
+                    ? "bg-orange-100 text-orange-700"
+                    : "text-gray-600 hover:bg-orange-50 hover:text-orange-600"
+                )}
+              >
                 Đánh giá lô chế biến
               </Link>
-              <Link href="/dashboard/manager/processing/progresses" className={cn(
-                "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
-                pathname.startsWith("/dashboard/manager/processing/progresses")
-                  ? "bg-orange-100 text-orange-700"
-                  : "text-gray-600 hover:bg-orange-50 hover:text-orange-600"
-              )}>
+              <Link
+                href="/dashboard/manager/processing/progresses"
+                className={cn(
+                  "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                  pathname.startsWith(
+                    "/dashboard/manager/processing/progresses"
+                  )
+                    ? "bg-orange-100 text-orange-700"
+                    : "text-gray-600 hover:bg-orange-50 hover:text-orange-600"
+                )}
+              >
                 Tiến trình lô chế biến
               </Link>
-              <Link href="/dashboard/manager/processing/wastes" className={cn(
-                "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
-                pathname.startsWith("/dashboard/manager/processing/wastes")
-                  ? "bg-orange-100 text-orange-700"
-                  : "text-gray-600 hover:bg-orange-50 hover:text-orange-600"
-              )}>
+              <Link
+                href="/dashboard/manager/processing/wastes"
+                className={cn(
+                  "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                  pathname.startsWith("/dashboard/manager/processing/wastes")
+                    ? "bg-orange-100 text-orange-700"
+                    : "text-gray-600 hover:bg-orange-50 hover:text-orange-600"
+                )}
+              >
                 Chất thải lô chế biến
               </Link>
-              <Link href="/dashboard/manager/processing/methods" className={cn(
-                "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
-                pathname.startsWith("/dashboard/manager/processing/methods")
-                  ? "bg-orange-100 text-orange-700"
-                  : "text-gray-600 hover:bg-orange-50 hover:text-orange-600"
-              )}>
+              <Link
+                href="/dashboard/manager/processing/methods"
+                className={cn(
+                  "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                  pathname.startsWith("/dashboard/manager/processing/methods")
+                    ? "bg-orange-100 text-orange-700"
+                    : "text-gray-600 hover:bg-orange-50 hover:text-orange-600"
+                )}
+              >
                 Phương pháp chế biến
               </Link>
-              <Link href="/dashboard/manager/processing/parameters" className={cn(
-                "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
-                pathname.startsWith("/dashboard/manager/processing/parameters")
-                  ? "bg-orange-100 text-orange-700"
-                  : "text-gray-600 hover:bg-orange-50 hover:text-orange-600"
-              )}>
+              <Link
+                href="/dashboard/manager/processing/parameters"
+                className={cn(
+                  "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                  pathname.startsWith(
+                    "/dashboard/manager/processing/parameters"
+                  )
+                    ? "bg-orange-100 text-orange-700"
+                    : "text-gray-600 hover:bg-orange-50 hover:text-orange-600"
+                )}
+              >
                 Tham số chế biến
               </Link>
-              <Link href="/dashboard/manager/processing/stages" className={cn(
-                "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
-                pathname.startsWith("/dashboard/manager/processing/stages")
-                  ? "bg-orange-100 text-orange-700"
-                  : "text-gray-600 hover:bg-orange-50 hover:text-orange-600"
-              )}>
+              <Link
+                href="/dashboard/manager/processing/stages"
+                className={cn(
+                  "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                  pathname.startsWith("/dashboard/manager/processing/stages")
+                    ? "bg-orange-100 text-orange-700"
+                    : "text-gray-600 hover:bg-orange-50 hover:text-orange-600"
+                )}
+              >
                 Công đoạn chế biến
               </Link>
-              <Link href="/dashboard/manager/processing/waste-disposals" className={cn(
-                "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
-                pathname.startsWith("/dashboard/manager/processing/waste-disposals")
-                  ? "bg-orange-100 text-orange-700"
-                  : "text-gray-600 hover:bg-orange-50 hover:text-orange-600"
-              )}>
+              <Link
+                href="/dashboard/manager/processing/waste-disposals"
+                className={cn(
+                  "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                  pathname.startsWith(
+                    "/dashboard/manager/processing/waste-disposals"
+                  )
+                    ? "bg-orange-100 text-orange-700"
+                    : "text-gray-600 hover:bg-orange-50 hover:text-orange-600"
+                )}
+              >
                 Xử lý chất thải lô chế biến
               </Link>
             </div>
@@ -521,19 +579,21 @@ export function SidebarGroup() {
               {
                 label: "Yêu cầu xuất kho",
                 href: "/dashboard/manager/warehouse-request",
-                activeMatch: (path: string) => path === "/dashboard/manager/warehouse-request",
+                activeMatch: (path: string) =>
+                  path === "/dashboard/manager/warehouse-request",
               },
               {
                 label: "Kho hàng",
                 href: "/dashboard/manager/warehouses",
-                activeMatch: (path: string) => path === "/dashboard/manager/warehouses",
+                activeMatch: (path: string) =>
+                  path === "/dashboard/manager/warehouses",
               },
               {
                 label: "Lịch sử tồn kho",
                 href: "/dashboard/manager/inventory-logs",
-                activeMatch: (path: string) => path === "/dashboard/manager/warehouse-request",
+                activeMatch: (path: string) =>
+                  path === "/dashboard/manager/warehouse-request",
               },
-
             ];
 
             const isActive = links.some((item) => item.activeMatch(pathname));
@@ -555,7 +615,9 @@ export function SidebarGroup() {
                     </span>
                     <span className="truncate">Vận hành kho</span>
                   </div>
-                  <FiChevronDown className={cn("transition", processingOpen && "rotate-180")} />
+                  <FiChevronDown
+                    className={cn("transition", processingOpen && "rotate-180")}
+                  />
                 </button>
 
                 {processingOpen && (
@@ -590,26 +652,32 @@ export function SidebarGroup() {
               {
                 label: "Yêu cầu nhập kho",
                 href: "/dashboard/staff/inbounds",
-                activeMatch: (path: string) => path === "/dashboard/staff/inbounds",
+                activeMatch: (path: string) =>
+                  path === "/dashboard/staff/inbounds",
               },
               {
                 label: "Phiếu nhập kho",
                 href: "/dashboard/staff/receipts",
-                activeMatch: (path: string) => path === "/dashboard/staff/receipts",
+                activeMatch: (path: string) =>
+                  path === "/dashboard/staff/receipts",
               },
               {
                 label: "Yêu cầu xuất kho",
                 href: "/dashboard/staff/outbounds",
-                activeMatch: (path: string) => path === "/dashboard/staff/outbounds",
+                activeMatch: (path: string) =>
+                  path === "/dashboard/staff/outbounds",
               },
               {
                 label: "Phiếu xuất kho",
                 href: "/dashboard/staff/outbound-receipts",
-                activeMatch: (path: string) => path === "/dashboard/staff/outbound-receipts",
+                activeMatch: (path: string) =>
+                  path === "/dashboard/staff/outbound-receipts",
               },
             ];
 
-            const isOperationActive = operationLinks.some((item) => item.activeMatch(pathname));
+            const isOperationActive = operationLinks.some((item) =>
+              item.activeMatch(pathname)
+            );
 
             return (
               <div>
@@ -628,7 +696,9 @@ export function SidebarGroup() {
                     </span>
                     <span className="truncate">Vận hành kho</span>
                   </div>
-                  <FiChevronDown className={cn("transition", processingOpen && "rotate-180")} />
+                  <FiChevronDown
+                    className={cn("transition", processingOpen && "rotate-180")}
+                  />
                 </button>
 
                 {processingOpen && (
@@ -659,21 +729,26 @@ export function SidebarGroup() {
               {
                 label: "Tồn kho",
                 href: "/dashboard/staff/inventories",
-                activeMatch: (path: string) => path === "/dashboard/staff/inventories",
+                activeMatch: (path: string) =>
+                  path === "/dashboard/staff/inventories",
               },
               {
                 label: "Nhật ký tồn kho",
                 href: "/dashboard/staff/inventory-logs",
-                activeMatch: (path: string) => path.startsWith("/dashboard/staff/inventory-logs"),
+                activeMatch: (path: string) =>
+                  path.startsWith("/dashboard/staff/inventory-logs"),
               },
               {
                 label: "Kho hàng",
                 href: "/dashboard/staff/warehouses",
-                activeMatch: (path: string) => path.startsWith("/dashboard/staff/warehouses"),
+                activeMatch: (path: string) =>
+                  path.startsWith("/dashboard/staff/warehouses"),
               },
             ];
 
-            const isDropdownActive = warehouseLinks.some((item) => item.activeMatch(pathname));
+            const isDropdownActive = warehouseLinks.some((item) =>
+              item.activeMatch(pathname)
+            );
 
             return (
               <div>
@@ -692,7 +767,9 @@ export function SidebarGroup() {
                     </span>
                     <span className="truncate">Quản lý kho</span>
                   </div>
-                  <FiChevronDown className={cn("transition", processingOpen && "rotate-180")} />
+                  <FiChevronDown
+                    className={cn("transition", processingOpen && "rotate-180")}
+                  />
                 </button>
 
                 {processingOpen && (
@@ -718,13 +795,6 @@ export function SidebarGroup() {
           })()}
         </>
       )}
-
-
-
-
-
-
-
     </div>
   );
 }
@@ -764,6 +834,5 @@ export function SidebarFooter({ isCollapsed }: SidebarFooterProps) {
         Đăng xuất
       </button>
     </div>
-
   );
 }


### PR DESCRIPTION
## ☕ Feature: Manager – Supply Contracts & Procurement Plans

---

### 📌 Objective  
Refactor manager dashboard and sidebar navigation to distinguish between **supply-side contracts with B2B buyers** and **procurement plans from farmers**.

---

### ✅ Key Changes
- Updated dashboard card titles and descriptions
- Renamed "Hợp đồng thu mua" → "Hợp đồng cung ứng" (Supply Contracts)
- Added a new dashboard card for "Kế hoạch thu mua" (Procurement Plans)
- Updated sidebar labels to match terminology

---

### 📁 Affected Files
- `src/app/dashboard/manager/page.tsx`
- `src/components/ui/sidebar.tsx`

---

### 🧪 How to Test
1. Visit: `/dashboard/manager`
2. Check that:
   - The card **"Hợp đồng cung ứng"** links to `/dashboard/manager/contracts`
   - The card **"Kế hoạch thu mua"** links to `/dashboard/manager/procurement-plans`
   - Sidebar reflects updated labels

---

### 🧪 Test Case
- [x] ✅ Clicking "Hợp đồng cung ứng" redirects to contract list page
- [x] ✅ Sidebar navigation highlights correctly
- [x] ✅ Wording is consistent across views
- [x] ❌ No layout shift or UI regression in other cards

---

### 🔍 Notes
- Icons reused from `react-icons/fi` for consistency
- Wording updated to reflect correct business flow: intermediary between farmers and buyers
- No API changes involved

---

### 🔗 Related
- Module: `Manager / Dashboard`
- Role: `Manager`

---

### ☑️ Checklist (before PR)
- [x] All links tested manually
- [x] Console clean from warnings or errors
- [x] Commit message and description use consistent terminology
