### PR TITLE
feat(expert): update anomaly report UI to refresh status after feedback

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/expert/anomalies/AdviceHistoryDialog.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/expert/anomalies/AdviceHistoryDialog.tsx
@@ -206,7 +206,7 @@ export default function AdviceHistoryDialog({ advices, onClose }: Props) {
                                                     href={advice.attachedFileUrl}
                                                     target="_blank"
                                                     rel="noopener noreferrer"
-                                                    className="text-blue-600 underline block mt-2 flex items-center gap-1"
+                                                    className="text-blue-600 underline flex mt-2 items-center gap-1"
                                                 >
                                                     <Paperclip size={14} /> Tệp đính kèm
                                                 </a>

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/expert/anomalies/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/expert/anomalies/page.tsx
@@ -112,13 +112,15 @@ export default function ReportResponsePage() {
                                 setFilteredAdvices([]);
 
                                 // Load lại danh sách phản hồi mới
-                                getAllExpertAdvices()
-                                    .then((all) => {
-                                        setAllAdvices(all);
-                                        const filtered = all.filter((a) => a.reportId === selectedReportId);
+                                Promise.all([getAllExpertAdvices(), getAllFarmerReports()])
+                                    .then(([advices, reports]) => {
+                                        setAllAdvices(advices);
+                                        setReports(reports); // 👈 cập nhật lại trạng thái báo cáo
+
+                                        const filtered = advices.filter((a) => a.reportId === selectedReportId);
                                         setFilteredAdvices(filtered);
                                     })
-                                    .catch(() => toast.error('Không thể tải lại phản hồi sau khi gửi'));
+                                    .catch(() => toast.error('Không thể tải lại dữ liệu sau khi gửi phản hồi'));
                             }}
                         />
 


### PR DESCRIPTION
## ☕ Tính năng: [Expert] – Phản hồi báo cáo bất thường

---

### 📌 Mục tiêu
Chuyên gia gửi phản hồi cho báo cáo của nông dân và cập nhật trạng thái `Đã phản hồi` ngay sau khi gửi, thuộc luồng xử lý sự cố mùa vụ.

---

### ✅ Thay đổi chính
- Gửi phản hồi từ `ExpertAdviceForm` sẽ cập nhật luôn trạng thái báo cáo (`isResolved`)
- Cập nhật lại danh sách `FarmerReports` sau khi gửi thành công
- Tối ưu UX: không reload toàn trang, chỉ cập nhật lại state

---

### 📁 File ảnh hưởng
- `src/app/dashboard/expert/anomalies/page.tsx`
- `src/app/dashboard/expert/anomalies/AdviceHistoryDialog.tsx`

---

### 🧪 Cách kiểm tra
1. Truy cập: `/dashboard/expert/anomalies`
2. Chọn 1 báo cáo chưa phản hồi
3. Nhấn `✏️ Gửi phản hồi` → điền nội dung → Gửi
4. Quan sát trạng thái báo cáo chuyển sang `Đã phản hồi` **ngay lập tức**
5. Nhấn `📜 Xem lịch sử phản hồi` để xem lại nội dung

---

### 🧪 Test Case
- [x] ✅ Gửi phản hồi thành công, cập nhật trạng thái báo cáo
- [x] ✅ Gửi phản hồi và đóng form, reload dữ liệu đúng
- [x] ❌ Không gửi phản hồi nếu thiếu nội dung
- [x] ✅ Danh sách lịch sử hiển thị đúng theo báo cáo đã chọn

---

### 🔍 Ghi chú
- Dữ liệu phản hồi và trạng thái `isResolved` lấy từ API
- Sử dụng lại hàm `getAllFarmerReports()` để đảm bảo cập nhật đồng bộ

---

### 🔗 Liên quan
- Module: `ExpertAdvice`
- Role: `AgriculturalExpert`
- Luồng: Phản hồi sự cố mùa vụ (Luồng 2)

---

### ☑️ Checklist (trước khi tạo PR)
- [x] Đã test đầy đủ các case
- [x] Đã kiểm tra lỗi console / warning
- [x] Đã dùng ngôn ngữ rõ ràng trong commit & description
