### PR TITLE
feat(contract): implement ContractForm for create and update with nested ContractItems

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/contracts/[id]/edit/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/contracts/[id]/edit/page.tsx
@@ -1,1 +1,110 @@
+"use client";
 
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { getContractDetails } from "@/lib/api/contracts";
+import { ContractViewDetailsDto, ContractUpdateDto } from "@/lib/api/contracts";
+import ContractForm from "@/components/contracts/ContractForm";
+import { Loader } from "lucide-react";
+import {
+  getAllBusinessBuyers,
+  BusinessBuyerDto,
+} from "@/lib/api/businessBuyers";
+import { ContractStatus } from "@/lib/constants/contractStatus";
+
+export default function EditContractPage() {
+  const params = useParams();
+  const rawId = params.id;
+  const router = useRouter();
+
+  const [initialData, setInitialData] = useState<ContractUpdateDto | null>(
+    null
+  );
+  const [loading, setLoading] = useState(true);
+  const [buyers, setBuyers] = useState<BusinessBuyerDto[]>([]);
+
+  useEffect(() => {
+  if (!rawId || typeof rawId !== "string") {
+    console.warn("Không có contractId hợp lệ");
+    setLoading(false);
+    return;
+  }
+
+  const id: string = rawId;
+
+  async function fetchData() {
+    try {
+      const [contract, buyerList] = await Promise.all([
+        getContractDetails(id),
+        getAllBusinessBuyers(),
+      ]);
+
+      if (!contract || !contract.contractItems) {
+        throw new Error("Hợp đồng không tồn tại hoặc thiếu contractItems");
+      }
+
+      setBuyers(buyerList);
+
+      const updateDto: ContractUpdateDto = {
+        contractId: contract.contractId,
+        contractNumber: contract.contractNumber,
+        contractTitle: contract.contractTitle,
+        contractFileUrl: contract.contractFileUrl,
+        buyerId: contract.buyerId,
+        deliveryRounds: contract.deliveryRounds ?? 1,
+        totalQuantity: contract.totalQuantity ?? 0,
+        totalValue: contract.totalValue ?? 0,
+        startDate: contract.startDate,
+        endDate: contract.endDate,
+        signedAt: contract.signedAt,
+        status: contract.status as ContractStatus,
+        cancelReason: contract.cancelReason,
+        contractItems: contract.contractItems.map((item) => ({
+          contractItemId: item.contractItemId,
+          contractId: contract.contractId,
+          coffeeTypeId: item.coffeeTypeId,
+          quantity: item.quantity ?? 0,
+          unitPrice: item.unitPrice ?? 0,
+          discountAmount: item.discountAmount ?? 0,
+          note: item.note ?? "",
+        })),
+      };
+
+      setInitialData(updateDto);
+    } catch (err) {
+      console.error("Lỗi khi load dữ liệu hợp đồng:", err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  fetchData();
+}, [rawId]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <Loader className="animate-spin w-6 h-6" />
+        <span className="ml-2">Đang tải dữ liệu hợp đồng...</span>
+      </div>
+    );
+  }
+
+  if (!initialData) {
+    return (
+      <div className="p-6 text-red-600 font-semibold">
+        Không tìm thấy hợp đồng với ID: {rawId}
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      <ContractForm
+        initialData={initialData}
+        buyerOptions={buyers}
+        onSuccess={() => router.push("/dashboard/manager/contracts")}
+      />
+    </div>
+  );
+}

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/contracts/create/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/contracts/create/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { useRouter } from "next/navigation";
+import ContractForm from "@/components/contracts/ContractForm";
+
+export default function CreateContractPage() {
+  const router = useRouter();
+
+  return (
+    <div className="p-6">
+      <ContractForm onSuccess={() => {
+        router.push("/dashboard/manager/contracts");
+      }} />
+    </div>
+  );
+}

--- a/DakLakCoffeeSupplyChain/src/components/contracts/ContractForm.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/contracts/ContractForm.tsx
@@ -1,0 +1,476 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { DatePicker } from "@/components/ui/DatePicker";
+import { DialogFooter } from "@/components/ui/dialog";
+import { ContractStatus } from "@/lib/constants/contractStatus";
+import {
+  ContractCreateDto,
+  ContractUpdateDto,
+  createContract,
+  updateContract,
+} from "@/lib/api/contracts";
+import {
+  getAllBusinessBuyers,
+  BusinessBuyerDto,
+} from "@/lib/api/businessBuyers";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+import { getCoffeeTypes, CoffeeType } from "@/lib/api/coffeeType";
+import {ContractItemCreateDto, ContractItemUpdateDto} from "@/lib/api/contractItems"
+
+type Props = {
+  initialData?: ContractUpdateDto;
+  onSuccess: () => void;
+  buyerOptions?: BusinessBuyerDto[];
+};
+
+export default function ContractForm({
+  initialData,
+  onSuccess,
+  buyerOptions,
+}: Props) {
+  const isEdit = !!initialData;
+  const [buyers, setBuyers] = useState<BusinessBuyerDto[]>([]);
+  const [coffeeTypes, setCoffeeTypes] = useState<CoffeeType[]>([]);
+  const [formData, setFormData] = useState<
+    ContractCreateDto | ContractUpdateDto | null
+  >(null);
+  const router = useRouter();
+
+  const getStatusDisplay = (status: string) => {
+    switch (status) {
+      case "NotStarted":
+        return {
+          label: "Chưa bắt đầu",
+          className: "bg-gray-100 text-gray-600",
+        };
+      case "PreparingDelivery":
+        return {
+          label: "Chuẩn bị giao",
+          className: "bg-purple-100 text-purple-700",
+        };
+      case "InProgress":
+        return {
+          label: "Đang thực hiện",
+          className: "bg-green-100 text-green-700",
+        };
+      case "PartialCompleted":
+        return {
+          label: "Hoàn thành một phần",
+          className: "bg-yellow-100 text-yellow-700",
+        };
+      case "Completed":
+        return { label: "Hoàn thành", className: "bg-blue-100 text-blue-700" };
+      case "Cancelled":
+        return { label: "Đã huỷ", className: "bg-red-100 text-red-700" };
+      case "Expired":
+        return { label: "Quá hạn", className: "bg-orange-100 text-orange-700" };
+      default:
+        return { label: status, className: "bg-gray-100 text-gray-600" };
+    }
+  };
+
+  // Fetch buyers list
+  useEffect(() => {
+    if (buyerOptions) {
+      setBuyers(buyerOptions);
+    } else {
+      getAllBusinessBuyers().then(setBuyers);
+    }
+  }, [buyerOptions]);
+
+  useEffect(() => {
+    getCoffeeTypes().then(setCoffeeTypes);
+  }, []);
+
+  // Sync formData based on initialData
+  useEffect(() => {
+    if (initialData) {
+      setFormData(initialData);
+    } else {
+      setFormData({
+        contractNumber: "",
+        contractTitle: "",
+        contractFileUrl: "",
+        buyerId: "" as any,
+        deliveryRounds: 1,
+        totalQuantity: 0,
+        totalValue: 0,
+        startDate: undefined,
+        endDate: undefined,
+        signedAt: undefined,
+        status: ContractStatus.NotStarted,
+        cancelReason: "",
+        contractItems: [],
+      });
+    }
+  }, [initialData]);
+
+  // Guard for null formData
+  if (!formData) {
+    return (
+      <div className="text-gray-500 text-center py-10">
+        Đang khởi tạo biểu mẫu hợp đồng...
+      </div>
+    );
+  }
+
+  function handleChange(field: string, value: any) {
+    setFormData((prev) => ({
+      ...prev!,
+      [field]: value,
+    }));
+  }
+
+  function addContractItem() {
+    setFormData((prev) => {
+      if (!prev) throw new Error("Form chưa khởi tạo");
+
+      const isUpdate = "contractId" in prev && "contractItems" in prev;
+
+      return {
+        ...prev,
+        contractItems: [
+          ...prev.contractItems,
+          {
+            contractId: isUpdate ? (prev as ContractUpdateDto).contractId : "",
+            coffeeTypeId: "",
+            quantity: 0,
+            unitPrice: 0,
+            discountAmount: 0,
+            note: "",
+            ...(isUpdate && { contractItemId: crypto.randomUUID() }),
+          },
+        ],
+      };
+    });
+  }
+
+  function updateContractItem(index: number, field: string, value: any) {
+    setFormData((prev) => {
+      const updatedItems = [...prev!.contractItems];
+      updatedItems[index] = { ...updatedItems[index], [field]: value };
+      return {
+        ...prev!,
+        contractItems: updatedItems,
+      };
+    });
+  }
+
+  function removeContractItem(index: number) {
+    setFormData((prev) => {
+      const updatedItems = [...prev!.contractItems];
+      updatedItems.splice(index, 1);
+      return {
+        ...prev!,
+        contractItems: updatedItems,
+      };
+    });
+  }
+
+async function handleSubmit(event: React.FormEvent) {
+      event.preventDefault();
+    try {
+      if (!formData) {
+        toast.error("Dữ liệu chưa sẵn sàng");
+        return;
+      }
+
+      const { contractItems, ...rest } = formData;
+console.log(formData)
+      if (!contractItems || contractItems.length === 0) {
+        toast.error("Vui lòng thêm ít nhất 1 mặt hàng vào hợp đồng.");
+        return;
+      }
+
+      if (isEdit) {
+        const dto = formData as ContractUpdateDto;
+
+        const normalizedItems: ContractItemUpdateDto[] = dto.contractItems.map(
+          (item) => ({
+            contractItemId: item.contractItemId,
+            contractId: item.contractId, // BẮT BUỘC
+            coffeeTypeId: item.coffeeTypeId,
+            quantity: item.quantity,
+            unitPrice: item.unitPrice,
+            discountAmount: item.discountAmount ?? 0,
+            note: item.note ?? "",
+          })
+        );
+
+        await updateContract(dto.contractId, {
+          ...dto,
+          contractFileUrl: dto.contractFileUrl?.trim() === "" ? undefined : dto.contractFileUrl,
+          contractItems: normalizedItems,
+        });
+
+        toast.success("Cập nhật hợp đồng thành công!");
+      } else {
+        const dto = formData as ContractCreateDto;
+
+        const normalizedItems: ContractItemCreateDto[] = dto.contractItems.map(
+          (item) => ({
+            coffeeTypeId: item.coffeeTypeId,
+            quantity: item.quantity,
+            unitPrice: item.unitPrice,
+            discountAmount: item.discountAmount ?? 0,
+            note: item.note ?? "",
+          })
+        );
+
+        await createContract({
+          ...dto,
+          contractFileUrl: dto.contractFileUrl?.trim() === "" ? undefined : dto.contractFileUrl,
+          contractItems: normalizedItems,
+        });
+
+        toast.success("Tạo hợp đồng thành công!");
+      }
+
+      onSuccess();
+    } catch (err) {
+      console.error("Lỗi khi submit hợp đồng:", err);
+      toast.error("Đã xảy ra lỗi khi lưu hợp đồng");
+    }
+  }
+
+  return (
+    <form className="max-w-4xl mx-auto bg-white border rounded-2xl shadow p-8 space-y-6">
+      <h2 className="text-2xl font-semibold text-center mb-6">
+        {isEdit ? "Chỉnh sửa hợp đồng" : "Tạo hợp đồng mới"}
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="block mb-1 text-sm font-medium">Số hợp đồng</label>
+          <Input
+            placeholder="VD: CT001"
+            value={formData.contractNumber}
+            onChange={(e) => handleChange("contractNumber", e.target.value)}
+            required
+          />
+        </div>
+
+        <div>
+          <label className="block mb-1 text-sm font-medium">Tiêu đề</label>
+          <Input
+            placeholder="Tiêu đề hợp đồng"
+            value={formData.contractTitle}
+            onChange={(e) => handleChange("contractTitle", e.target.value)}
+            required
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="block mb-1 text-sm font-medium">File hợp đồng</label>
+        <Input
+          placeholder="URL file"
+          value={formData.contractFileUrl || ""}
+          onChange={(e) => handleChange("contractFileUrl", e.target.value)}
+        />
+      </div>
+
+      <div>
+        <label className="block mb-1 text-sm font-medium">Đối tác</label>
+        <select
+          value={formData.buyerId}
+          onChange={(e) => handleChange("buyerId", e.target.value)}
+          className="w-full p-2 border rounded"
+          required
+        >
+          <option value="">-- Chọn đối tác --</option>
+          {buyers.map((buyer) => (
+            <option key={buyer.buyerId} value={buyer.buyerId}>
+              {buyer.companyName}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div>
+          <label className="block mb-1 text-sm font-medium">Số đợt</label>
+          <Input
+            type="number"
+            min={1}
+            value={formData.deliveryRounds || ""}
+            onChange={(e) =>
+              handleChange("deliveryRounds", Number(e.target.value))
+            }
+          />
+        </div>
+        <div>
+          <label className="block mb-1 text-sm font-medium">Tổng KL</label>
+          <Input
+            type="number"
+            value={formData.totalQuantity || ""}
+            onChange={(e) =>
+              handleChange("totalQuantity", Number(e.target.value))
+            }
+          />
+        </div>
+        <div>
+          <label className="block mb-1 text-sm font-medium">Tổng GT</label>
+          <Input
+            type="number"
+            value={formData.totalValue || ""}
+            onChange={(e) => handleChange("totalValue", Number(e.target.value))}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <DatePicker
+          label="Ngày bắt đầu"
+          value={formData.startDate as any}
+          onChange={(date) => handleChange("startDate", date)}
+          required
+        />
+        <DatePicker
+          label="Ngày kết thúc"
+          value={formData.endDate as any}
+          onChange={(date) => handleChange("endDate", date)}
+          required
+        />
+        <DatePicker
+          label="Ngày ký"
+          value={formData.signedAt as any}
+          onChange={(date) => handleChange("signedAt", date)}
+        />
+      </div>
+
+      <div>
+        <label className="block mb-1 text-sm font-medium">Trạng thái</label>
+        <select
+          className="w-full p-2 border rounded"
+          value={formData.status}
+          onChange={(e) => handleChange("status", e.target.value)}
+        >
+          {Object.entries(ContractStatus).map(([key, val]) => (
+            <option key={val} value={val}>
+              {getStatusDisplay(val).label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="block mb-1 text-sm font-medium">
+          Lý do huỷ (nếu có)
+        </label>
+        <Textarea
+          placeholder="Nếu huỷ, ghi lý do..."
+          value={formData.cancelReason}
+          onChange={(e) => handleChange("cancelReason", e.target.value)}
+        />
+      </div>
+
+      <div>
+        <label className="block mb-1 text-sm font-medium">
+          Danh sách mặt hàng
+        </label>
+
+        {formData.contractItems.map((item, index) => (
+          <div
+            key={index}
+            className="grid grid-cols-1 md:grid-cols-6 gap-2 mb-2"
+          >
+            {/* Loại cà phê */}
+            <select
+              value={item.coffeeTypeId}
+              onChange={(e) =>
+                updateContractItem(index, "coffeeTypeId", e.target.value)
+              }
+              className="p-2 border rounded"
+            >
+              <option value="">-- Chọn loại cà phê --</option>
+              {coffeeTypes.map((type) => (
+                <option key={type.coffeeTypeId} value={type.coffeeTypeId}>
+                  {type.typeName}
+                </option>
+              ))}
+            </select>
+
+            {/* Số lượng */}
+            <Input
+              placeholder="Số lượng"
+              type="number"
+              value={item.quantity}
+              onChange={(e) =>
+                updateContractItem(index, "quantity", Number(e.target.value))
+              }
+            />
+
+            {/* Đơn giá */}
+            <Input
+              placeholder="Đơn giá"
+              type="number"
+              value={item.unitPrice}
+              onChange={(e) =>
+                updateContractItem(index, "unitPrice", Number(e.target.value))
+              }
+            />
+
+            {/* Chiết khấu */}
+            <Input
+              placeholder="Chiết khấu"
+              type="number"
+              value={item.discountAmount || ""}
+              onChange={(e) =>
+                updateContractItem(
+                  index,
+                  "discountAmount",
+                  Number(e.target.value)
+                )
+              }
+            />
+
+            {/* Ghi chú */}
+            <Input
+              placeholder="Ghi chú"
+              value={item.note || ""}
+              onChange={(e) =>
+                updateContractItem(index, "note", e.target.value)
+              }
+            />
+
+            {/* Xoá */}
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => removeContractItem(index)}
+            >
+              Xoá
+            </Button>
+          </div>
+        ))}
+
+        <Button
+          type="button"
+          variant="outline"
+          onClick={addContractItem}
+          className="mt-2"
+        >
+          + Thêm mặt hàng
+        </Button>
+      </div>
+
+      <DialogFooter className="flex justify-between pt-4">
+        <Button type="submit" onClick={handleSubmit}>
+          <h2>Lưu hợp đồng</h2>
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => router.push("/dashboard/manager/contracts")}
+        >
+          Quay lại
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}

--- a/DakLakCoffeeSupplyChain/src/components/ui/DatePicker.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/ui/DatePicker.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Input } from "./input"; // hoặc từ shadcn nếu dùng
+import { Label } from "./label";
+
+type Props = {
+  label?: string;
+  value?: string;
+  onChange: (value: string) => void;
+  required?: boolean;
+};
+
+export function DatePicker({ label, value, onChange, required }: Props) {
+  return (
+    <div className="space-y-1">
+      {label && <Label className="text-sm">{label}</Label>}
+      <Input
+        type="date"
+        value={value || ""}
+        onChange={(e) => onChange(e.target.value)}
+        required={required}
+      />
+    </div>
+  );
+}

--- a/DakLakCoffeeSupplyChain/src/lib/api/businessBuyers.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/businessBuyers.ts
@@ -1,0 +1,18 @@
+import api from "./axios";
+
+export interface BusinessBuyerDto {
+  buyerId: string;
+  buyerCode: string;
+  companyName: string;
+  contactPerson: string;
+  position: string;
+  companyAddress: string;
+  createdAt: string;
+  createdByName: string;
+}
+
+// Gọi API để lấy danh sách tất cả buyers
+export async function getAllBusinessBuyers(): Promise<BusinessBuyerDto[]> {
+  const response = await api.get<BusinessBuyerDto[]>("/BusinessBuyers");
+  return response.data;
+}

--- a/DakLakCoffeeSupplyChain/src/lib/api/contractItems.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/contractItems.ts
@@ -1,7 +1,7 @@
 import api from "./axios";
 
 export interface ContractItemCreateDto {
-  contractId: string;
+  contractId?: string;
   coffeeTypeId: string;
   quantity: number;
   unitPrice: number;

--- a/DakLakCoffeeSupplyChain/src/lib/api/contracts.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/contracts.ts
@@ -1,4 +1,7 @@
 import api from "./axios";
+import { ContractStatus } from "@/lib/constants/contractStatus";
+import { ContractItemCreateDto } from "@/lib/api/contractItems";
+import { ContractItemUpdateDto } from "@/lib/api/contractItems";
 
 export interface Contract {
   id: string;
@@ -53,6 +56,7 @@ export interface ContractViewDetailsDto {
   contractTitle: string;
   contractFileUrl: string;
   sellerName: string;
+  buyerId: string;
   buyerName: string;
   deliveryRounds?: number;
   totalQuantity?: number;
@@ -65,6 +69,27 @@ export interface ContractViewDetailsDto {
   createdAt: string;
   updatedAt: string;
   contractItems: ContractItemViewDto[];
+}
+
+export interface ContractCreateDto {
+  buyerId: string;
+  contractNumber: string;
+  contractTitle: string;
+  contractFileUrl?: string;
+  deliveryRounds?: number;
+  totalQuantity?: number;
+  totalValue?: number;
+  startDate?: string; // hoặc DateOnly/Date tuỳ định dạng
+  endDate?: string;
+  signedAt?: string;
+  status: ContractStatus;
+  cancelReason: string;
+  contractItems: ContractItemCreateDto[];
+}
+
+export interface ContractUpdateDto extends ContractCreateDto {
+  contractId: string;
+  contractItems: ContractItemUpdateDto[]; // override để dùng loại Update thay vì Create
 }
 
 // Mock data for contracts
@@ -129,33 +154,33 @@ export async function getContractById(id: string): Promise<Contract | null> {
   return mockContracts.find((contract) => contract.id === id) || null;
 }
 
-// Create new contract
-export async function createContract(contract: Omit<Contract, "id" | "createdAt" | "updatedAt">): Promise<Contract> {
-  // TODO: Replace with actual API call
-  const newContract: Contract = {
-    ...contract,
-    id: Math.random().toString(36).substr(2, 9),
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-  };
-  mockContracts.push(newContract);
-  return newContract;
-}
+// // Create new contract
+// export async function createContract(contract: Omit<Contract, "id" | "createdAt" | "updatedAt">): Promise<Contract> {
+//   // TODO: Replace with actual API call
+//   const newContract: Contract = {
+//     ...contract,
+//     id: Math.random().toString(36).substr(2, 9),
+//     createdAt: new Date().toISOString(),
+//     updatedAt: new Date().toISOString(),
+//   };
+//   mockContracts.push(newContract);
+//   return newContract;
+// }
 
-// Update contract
-export async function updateContract(id: string, updates: Partial<Contract>): Promise<Contract | null> {
-  // TODO: Replace with actual API call
-  const index = mockContracts.findIndex((contract) => contract.id === id);
-  if (index === -1) return null;
+// // Update contract
+// export async function updateContract(id: string, updates: Partial<Contract>): Promise<Contract | null> {
+//   // TODO: Replace with actual API call
+//   const index = mockContracts.findIndex((contract) => contract.id === id);
+//   if (index === -1) return null;
 
-  const updatedContract = {
-    ...mockContracts[index],
-    ...updates,
-    updatedAt: new Date().toISOString(),
-  };
-  mockContracts[index] = updatedContract;
-  return updatedContract;
-}
+//   const updatedContract = {
+//     ...mockContracts[index],
+//     ...updates,
+//     updatedAt: new Date().toISOString(),
+//   };
+//   mockContracts[index] = updatedContract;
+//   return updatedContract;
+// }
 
 // Delete contract
 export async function deleteContract(id: string): Promise<boolean> {
@@ -210,3 +235,13 @@ export async function getContractDetails(contractId: string): Promise<ContractVi
 export async function softDeleteContract(contractId: string): Promise<void> {
   await api.patch(`/Contracts/soft-delete/${contractId}`);
 } 
+
+// Gọi API để tạo hợp đồng mới
+export async function createContract(data: ContractCreateDto): Promise<void> {
+  await api.post("/Contracts", data);
+}
+
+// Gọi API để cập nhật hợp đồng theo contractId
+export async function updateContract(contractId: string, data: ContractUpdateDto): Promise<void> {
+  await api.put(`/Contracts/${contractId}`, data);
+}

--- a/DakLakCoffeeSupplyChain/src/lib/constants/contractStatus.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/constants/contractStatus.ts
@@ -22,3 +22,30 @@ export const ContractStatusMap: Record<ContractStatusValue, {
   Cancelled: { label: "Đã hủy", color: "red", icon: "❌" },
   Expired: { label: "Quá hạn", color: "orange", icon: "⌛" },
 };
+
+export enum ContractStatus {
+  NotStarted = "NotStarted",
+  PreparingDelivery = "PreparingDelivery",
+  InProgress = "InProgress",
+  PartialCompleted = "PartialCompleted",
+  Completed = "Completed",
+  Cancelled = "Cancelled",
+  Expired = "Expired",
+}
+
+export function convertEnumStatusToApi(
+  status: ContractStatus
+): "open" | "in_progress" | "completed" {
+  switch (status) {
+    case ContractStatus.NotStarted:
+    case ContractStatus.PreparingDelivery:
+      return "open";
+    case ContractStatus.InProgress:
+    case ContractStatus.PartialCompleted:
+      return "in_progress";
+    case ContractStatus.Completed:
+      return "completed";
+    default:
+      return "open"; // fallback
+  }
+}


### PR DESCRIPTION
## ☕ Feature: Contract Form for Create & Update

### 📌 Objective
Build reusable `ContractForm` component to support both **creation** and **updating** of contracts. This includes nested `ContractItems`, integrated validation, and backend API connection for `POST`/`PUT` actions.

---

### ✅ Key Changes
- Implemented `ContractForm.tsx` to serve both create/edit use cases  
- Call `POST /api/Contracts` and `PUT /api/Contracts/{id}` using shared form logic  
- Connected contract form with `ContractItem` dynamic list  
- Added `DatePicker` UI component  
- Adjusted FE constants and updated `contractStatus.ts`  
- Refactored API logic in `contracts.ts` and `contractItems.ts`

---

### 🧱 Affected Files
- `page.tsx` (create/edit)
- `ContractForm.tsx`
- `contracts.ts`
- `contractItems.ts`
- `contractStatus.ts`

---

### 📁 Added
- `ContractForm.tsx`
- `DatePicker.tsx`
- `businessBuyers.ts`

---

### 🛠️ How to Test
1. Login bằng role `BusinessManager`
2. Truy cập:
   - `/dashboard/manager/contracts/create` để tạo mới
   - `/dashboard/manager/contracts/[id]/edit` để cập nhật
3. Điền đủ thông tin và submit:
   - ✅ Submit sẽ gọi `POST` hoặc `PUT` tương ứng và redirect về `/contracts`

---

### 🧪 Test Cases
- [x] ✅ Submit contract with multiple items – returns 200 OK  
- [x] ❌ Submit missing required fields – returns 400 with field-level errors  
- [x] ✅ Update existing contract with edited items – updated successfully  

---

### 🔍 Notes
- `ContractFileUrl` must be null or a valid URL (avoid empty string)  
- BE no longer requires `ContractId` when creating items via nested structure  
- Ensure FE does not send empty `contractId` in creation flow  

---

### 🔗 Related
- Modules: `Contract`, `ContractItem`  
- Roles: `BusinessManager`
