### PR TITLE
fix(crop-season): update getCropSeasonsForCurrentUser to use OData (///) and avoid empty ; return empty array on error

### DIFF
--- a/DakLakCoffeeSupplyChain/src/components/contract-delivery-batches/ContractDeliveryBatchForm.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/contract-delivery-batches/ContractDeliveryBatchForm.tsx
@@ -24,9 +24,9 @@ import { toDateOnly, fromDateOnly } from "@/lib/utils";
 
 export type ContractOption = { contractId: string; contractNumber: string };
 
-// ---------- Form State (cho phép undefined) ----------
+// Form State
 type DeliveryBatchFormState = {
-  // giống create DTO nhưng expectedDeliveryDate có thể undefined
+  // Giống create DTO nhưng expectedDeliveryDate có thể undefined
   contractId: string;
   deliveryRound: number;
   expectedDeliveryDate?: Date;
@@ -244,7 +244,7 @@ export default function ContractDeliveryBatchForm({
       return;
     }
 
-    // validate cơ bản
+    // Validate cơ bản
     if (!data.contractId) return toast.error("Vui lòng chọn hợp đồng.");
     if (!data.expectedDeliveryDate)
       return toast.error("Vui lòng chọn ngày dự kiến.");

--- a/DakLakCoffeeSupplyChain/src/lib/api/cropSeasons.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/cropSeasons.ts
@@ -73,29 +73,39 @@ export async function getAllCropSeasons(): Promise<CropSeasonListItem[]> {
 }
 
 // Lấy mùa vụ theo userId (dành cho Farmer - chỉ xem của mình)
+// OData version
 export async function getCropSeasonsForCurrentUser(params: {
   search?: string;
   status?: string;
   page?: number;
   pageSize?: number;
 }): Promise<CropSeasonListItem[]> {
+  const { search, status, page = 1, pageSize = 6 } = params ?? {};
+  const q: Record<string, string | number> = {};
+
+  // $search không được để rỗng
+  if (search && search.trim()) {
+    // thường $search cần để trong dấu ngoặc kép
+    q["$search"] = `"${search.trim()}"`;
+  }
+
+  if (status && status.trim()) {
+    // nếu field là enum/string -> nhớ escape nếu có ' trong giá trị
+    const safe = status.trim().replace(/'/g, "''");
+    q["$filter"] = `status eq '${safe}'`;
+  }
+
+  q["$top"] = pageSize;
+  q["$skip"] = (page - 1) * pageSize;
+
   try {
-    const res = await api.get<CropSeasonListItem[]>("/CropSeasons", {
-      params: {
-        search: params.search,
-        status: params.status,
-        page: params.page ?? 1,
-        pageSize: params.pageSize ?? 10,
-      }
-    });
+    const res = await api.get<CropSeasonListItem[]>("/CropSeasons", { params: q });
     return res.data;
   } catch (err) {
     console.error("Lỗi getCropSeasonsForCurrentUser:", err);
     return [];
   }
 }
-
-
 
 // Lấy chi tiết 1 mùa vụ (bao gồm danh sách vùng trồng)
 export async function getCropSeasonById(id: string): Promise<CropSeason | null> {


### PR DESCRIPTION
## ☕ Feature: [Farmer] – Update crop season fetching to OData

---

### 📌 Objective
Refactor the `getCropSeasonsForCurrentUser` API call for the Farmer role to fully align with OData query parameters and prevent server errors caused by empty `$search`.

---

### ✅ Main Changes
- Updated `getCropSeasonsForCurrentUser` to use `$search`, `$filter`, `$top`, `$skip` instead of custom REST params.
- Added condition to avoid sending `$search` when empty.
- Returned an empty array on API errors to prevent UI crashes.
- Minor adjustments in `ContractDeliveryBatchForm` (no behavior change).

---

### 📁 Affected Files
- `DakLakCoffeeSupplyChain/src/lib/api/cropSeasons.ts`
- `DakLakCoffeeSupplyChain/src/components/contract-delivery-batches/ContractDeliveryBatchForm.tsx`

---

### 🧪 How to Test
1. Log in as **Farmer** and navigate to: `/dashboard/farmer/crop-seasons`
2. Verify:
   - Crop seasons load successfully with and without search text.
   - Status filter works correctly.
   - Pagination fetches data as expected.
3. Confirm that empty search does not cause a 400 error.

---

### 🧪 Test Cases
- [x] ✅ Load crop seasons list without search text → returns results without error.
- [x] ✅ Search by keyword → filters correctly.
- [x] ❌ Empty `$search` param should not be sent.
- [x] ✅ Status filter applies as expected.
- [x] ✅ Pagination works without breaking filters.

---

### 🔍 Notes
- OData requires `$search` to be wrapped in quotes and non-empty.
- `$filter` now escapes single quotes in status values.
- No visual/UI changes for the delivery batch form.

---

### 🔗 Related
- Module: `CropSeasons`, `ContractDeliveryBatch`
- Role: `Farmer`, `Manager`

---

### ☑️ Checklist (before creating PR)
- [x] Tested all scenarios for both empty and filled search inputs.
- [x] Checked for console errors/warnings.
- [x] Used clear commit messages and PR description.
