### PR TITLE
feat(role4): update UI for warehouse inbound receipt creation and inv…

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/auth/login/workspace.code-workspace
+++ b/DakLakCoffeeSupplyChain/src/app/auth/login/workspace.code-workspace
@@ -1,0 +1,4 @@
+{
+	"folders": [],
+	"settings": {}
+}

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/staff/receipts/create/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/staff/receipts/create/page.tsx
@@ -1,32 +1,55 @@
 'use client';
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createWarehouseReceipt } from "@/lib/api/warehouseReceipt";
 import { getAllWarehouses } from "@/lib/api/warehouses";
 import { getAllInboundRequests } from "@/lib/api/warehouseInboundRequest";
+import { getInventoriesByWarehouseId, createInventory } from "@/lib/api/inventory";
 
 import {
   Card, CardHeader, CardTitle, CardContent
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Select, SelectTrigger, SelectContent, SelectItem
 } from "@/components/ui/select";
 
-type Warehouse = {
-  warehouseId: string;
-  name: string;
-};
+type Warehouse = { warehouseId: string; name: string; };
 
 type InboundRequest = {
   inboundRequestId: string;
   requestCode: string;
   status: string;
-  batchId: string; // ✅ Thêm batchId ở đây
+  batchId: string;
 };
+
+type InventoryRaw = any;
+type Inventory = {
+  inventoryId: string;
+  batchId?: string;
+  productName?: string;
+  quantity?: number;
+  unit?: string;
+};
+
+function normalizeInventory(x: InventoryRaw): Inventory {
+  return {
+    inventoryId: x.inventoryId ?? x.id ?? x.inventoryID ?? x.InventoryID,
+    batchId:
+      x.batchId ??
+      x.BatchId ??
+      x.batchID ??
+      x.BatchID ??
+      x?.batch?.id ??
+      x?.processingBatchId ??
+      x?.ProcessingBatchId,
+    productName: x.productName ?? x.ProductName ?? x?.product?.name ?? x.Name,
+    quantity: x.quantity ?? x.Quantity ?? x.quantityKg ?? x.Qty,
+    unit: x.unit ?? x.Unit ?? (x.quantityKg ? "kg" : undefined),
+  };
+}
 
 export default function CreateReceiptPage() {
   const [warehouses, setWarehouses] = useState<Warehouse[]>([]);
@@ -34,9 +57,13 @@ export default function CreateReceiptPage() {
 
   const [warehouseId, setWarehouseId] = useState('');
   const [inboundRequestId, setInboundRequestId] = useState('');
-  const [receivedQuantity, setReceivedQuantity] = useState(0);
   const [note, setNote] = useState('');
   const [error, setError] = useState('');
+
+  const [allInvOfWarehouse, setAllInvOfWarehouse] = useState<Inventory[]>([]);
+  const [invLoading, setInvLoading] = useState(false);
+  const [invError, setInvError] = useState('');
+  const [creatingInv, setCreatingInv] = useState(false);
 
   const router = useRouter();
 
@@ -44,13 +71,10 @@ export default function CreateReceiptPage() {
     const fetchData = async () => {
       try {
         const res = await getAllWarehouses();
-        if (res.status === 1) {
-          setWarehouses(res.data);
-        } else {
-          alert("❌ Không thể tải danh sách kho: " + res.message);
-        }
+        if (res.status === 1) setWarehouses(res.data);
+        else alert("❌ Không thể tải danh sách kho: " + res.message);
       } catch (err: any) {
-        console.error("❌ Exception khi gọi getAllWarehouses:", err);
+        console.error("❌ getAllWarehouses:", err);
         alert("❌ Lỗi không xác định khi tải danh sách kho");
       }
 
@@ -63,7 +87,7 @@ export default function CreateReceiptPage() {
           alert("❌ Không thể tải phiếu yêu cầu nhập kho: " + resInbound.message);
         }
       } catch (err: any) {
-        console.error("❌ Exception khi gọi getAllInboundRequests:", err);
+        console.error("❌ getAllInboundRequests:", err);
         alert("❌ Lỗi không xác định khi tải phiếu yêu cầu nhập kho");
       }
     };
@@ -71,25 +95,98 @@ export default function CreateReceiptPage() {
     fetchData();
   }, []);
 
+  useEffect(() => {
+    setAllInvOfWarehouse([]);
+    setInvError('');
+    if (!warehouseId) return;
+
+    let canceled = false;
+    (async () => {
+      try {
+        setInvLoading(true);
+        const payload = await getInventoriesByWarehouseId(warehouseId);
+        const listRaw = Array.isArray(payload) ? payload : (payload?.data ?? []);
+        const list: Inventory[] = (listRaw || []).map(normalizeInventory);
+
+        if (canceled) return;
+        setAllInvOfWarehouse(list);
+      } catch (err: any) {
+        if (!canceled) {
+          console.error("❌ getInventoriesByWarehouseId:", err);
+          setInvError(err?.message || "Lỗi khi tải tồn kho của kho.");
+        }
+      } finally {
+        if (!canceled) setInvLoading(false);
+      }
+    })();
+
+    return () => { canceled = true; };
+  }, [warehouseId]);
+
+  const selectedRequest = useMemo(
+    () => inboundRequests.find(r => r.inboundRequestId === inboundRequestId),
+    [inboundRequestId, inboundRequests]
+  );
+
+  const filteredInv = useMemo(() => {
+    const b = selectedRequest?.batchId?.toLowerCase()?.trim();
+    if (!b) return [];
+    return (allInvOfWarehouse || []).filter(iv =>
+      iv.batchId?.toLowerCase()?.trim() === b
+    );
+  }, [allInvOfWarehouse, selectedRequest?.batchId]);
+
+  // ✅ Tính tổng tồn kho hiện có của batch tại kho
+  const totalExisting = useMemo(
+    () => (filteredInv || []).reduce((s, x) => s + (Number(x.quantity) || 0), 0),
+    [filteredInv]
+  );
+
+  async function handleCreateEmptyInventory() {
+    if (!warehouseId || !selectedRequest?.batchId) return;
+    setCreatingInv(true);
+    setError('');
+    try {
+      const payload = {
+        warehouseId,
+        batchId: selectedRequest.batchId,
+        quantity: 0,
+        unit: "kg",
+        note: "Khởi tạo tồn kho trống từ màn tạo phiếu",
+      };
+      const res = await createInventory(payload);
+      if ((res.status >= 200 && res.status < 300) || res.status === 200 || res.status === 201) {
+        alert("✅ Đã tạo tồn kho trống cho kho + lô này.");
+        const payloadAfter = await getInventoriesByWarehouseId(warehouseId);
+        const listRaw = Array.isArray(payloadAfter) ? payloadAfter : (payloadAfter?.data ?? []);
+        setAllInvOfWarehouse((listRaw || []).map(normalizeInventory));
+      } else {
+        setError(res.message || "Không tạo được tồn kho trống.");
+      }
+    } catch (e: any) {
+      setError(e?.message || "Không tạo được tồn kho trống.");
+    } finally {
+      setCreatingInv(false);
+    }
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
 
-    if (!warehouseId || !inboundRequestId || receivedQuantity <= 0) {
-      setError('Vui lòng điền đầy đủ thông tin và số lượng hợp lệ');
+    if (!warehouseId || !inboundRequestId) {
+      setError('Vui lòng chọn đầy đủ Phiếu yêu cầu và Kho.');
       return;
     }
-
-    const selectedRequest = inboundRequests.find(r => r.inboundRequestId === inboundRequestId);
-    if (!selectedRequest || !selectedRequest.batchId) {
+    if (!selectedRequest?.batchId) {
       setError("Không tìm thấy batchId tương ứng với phiếu yêu cầu.");
       return;
     }
 
     const receiptData = {
       warehouseId,
-      batchId: selectedRequest.batchId, // ✅ Thêm batchId vào object
-      receivedQuantity,
+      batchId: selectedRequest.batchId,
+      receivedQuantity: 0,
       note,
     };
 
@@ -115,7 +212,7 @@ export default function CreateReceiptPage() {
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-4">
-            {error && <div className="text-red-500">{error}</div>}
+            {error && <div className="text-red-600">{error}</div>}
 
             {/* Inbound Request */}
             <div>
@@ -159,17 +256,61 @@ export default function CreateReceiptPage() {
               </Select>
             </div>
 
-            {/* Received quantity */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700">Số lượng nhận (kg)</label>
-              <Input
-                type="number"
-                value={receivedQuantity}
-                onChange={(e) => setReceivedQuantity(Number(e.target.value))}
-                className="mt-1"
-                min="1"
-              />
+            {/* Hint */}
+            <div className="text-sm text-gray-700 bg-amber-50 border border-amber-200 rounded p-3">
+              Số lượng thực nhận sẽ được nhập khi <b>xác nhận phiếu</b>. Ở bước tạo, hệ thống mặc định <b>0&nbsp;kg</b>.
             </div>
+
+            {/* INVENTORY */}
+            {(warehouseId || selectedRequest?.batchId) && (
+              <div className="border rounded p-3 space-y-2">
+                <div className="font-medium">Tồn kho theo lô tại kho đã chọn:</div>
+
+                {!warehouseId || !selectedRequest?.batchId ? (
+                  <div className="text-sm text-gray-600">Hãy chọn đầy đủ Phiếu và Kho để xem tồn.</div>
+                ) : invLoading ? (
+                  <div className="text-sm text-gray-600">Đang tải tồn kho...</div>
+                ) : invError ? (
+                  <div className="text-sm text-red-600">{invError}</div>
+                ) : filteredInv.length === 0 ? (
+                  <div className="space-y-2">
+                    <div className="text-sm text-gray-700">
+                      Chưa có tồn kho cho <b>lô này</b> tại <b>kho đã chọn</b>.<br />
+                      Hệ thống sẽ <b>tự tạo tồn kho</b> khi bạn <b>xác nhận phiếu</b>.
+                    </div>
+                    <div>
+                      <Button
+                        type="button"
+                        onClick={handleCreateEmptyInventory}
+                        disabled={!warehouseId || !selectedRequest?.batchId || creatingInv}
+                        className="bg-amber-600 text-white hover:bg-amber-700"
+                      >
+                        {creatingInv ? "Đang tạo..." : "Tạo tồn kho trống (0 kg)"}
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <ul className="divide-y">
+                      {filteredInv.map(iv => (
+                        <li key={iv.inventoryId} className="py-2 flex justify-between">
+                          <span className="text-sm">{iv.productName}</span>
+                          <span className="text-sm font-medium">
+                            {iv.quantity} {iv.unit || "kg"}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                    {/* ✅ Callout */}
+                    <div className="mt-3 rounded border border-blue-200 bg-blue-50 text-blue-800 text-sm p-3">
+                      Đã có tồn kho cho lô này tại kho đã chọn (tổng hiện có <b>{totalExisting}</b> kg).  
+                      Khi bạn <b>xác nhận phiếu</b>, hệ thống sẽ <b>cộng dồn</b> khối lượng vào tồn kho hiện có.  
+                      Nếu chưa có tồn, hệ thống sẽ <b>tự tạo mới</b>.
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
 
             {/* Note */}
             <div>


### PR DESCRIPTION
feat(role4): update UI for warehouse inbound receipt creation and inventory display
☕ Feature: Role4 – Warehouse Receipt UI Updates
📌 Objective
Unify and improve the staff-facing UI for creating and confirming Warehouse Receipts:

Create receipts from Approved inbound requests

Clearly show existing inventory for the selected warehouse & batch

Guide users that quantity is only provided at confirmation time

Provide robust validation and feedback

✅ Key Changes
Create page (/dashboard/staff/receipts/create)

Load warehouses and inbound requests (filtered to Approved only)

Show an Inventory panel filtered by selected warehouse + batch

If inventory exists → list current quantity (kg)

If not → allow “Create empty inventory (0 kg)” bootstrap button

Hint text clarifying that received quantity is set at confirmation, not at creation

Form validation and friendly error messages

Detail page (/dashboard/staff/receipts/[id])

Display receipt info (warehouse, batch, quantity, staff, notes)

Status determined by receivedAt (confirmed vs not confirmed)

Confirmation form with:

Quantity > 0 validation

Mandatory note if confirmed quantity < initial created amount

Disabled state while submitting

Success & error banners (no silent failures)

API helpers

Standardized safeFetch for token + error handling

Unified confirmWarehouseReceipt to return actionable messages

Defensive parsing of JSON/text responses

📁 Affected Files
src/app/dashboard/staff/receipts/create/page.tsx

src/app/dashboard/staff/receipts/[id]/page.tsx

src/lib/api/warehouseReceipt.ts

🧪 How to Test
Log in as BusinessStaff to get a valid JWT.

Ensure there is at least one Approved inbound request with a valid batchId.

Go to Create Receipt:
/dashboard/staff/receipts/create

Select an Approved request and a Warehouse

If the inventory panel shows no records, optionally click “Create empty inventory (0 kg)”

Submit to create a receipt (quantity is NOT set here)

Open Receipt Detail:
/dashboard/staff/receipts/{receiptId}

Confirm receipt with a positive quantity

Observe success banner and status change (confirmed)

If the quantity exceeds allowed/requested constraints (BE), expect a clear error banner

🧪 Test Case
 ✅ Create receipt with valid request + warehouse → success, navigates to list

 ✅ Confirm receipt with valid quantity → success, form hides, status becomes “Confirmed”

 ❌ Confirm quantity <= 0 → client-side validation error

 ❌ Confirm quantity > allowed/requested → server error surfaced to user

 ✅ Inventory panel shows current quantity when existing, shows “Create empty inventory” when not

🔍 Notes
Uses components from @/components/ui and lucide-react

Status derived from receivedAt (more reliable than parsing note text)

Error handling avoids silent failures; banners shown on the page

Inventory list is normalized defensively against varying field shapes

🔗 Related
Module: Warehouse, Inventory, Inbound Requests

Role: BusinessStaff

☑️ Checklist (before opening PR)
 No console errors/warnings during flows

 Validations for all input cases

 Clear success/error messages

 UI responsive for common viewports