### PR TITLE
feat(contract-ui): update contract status handling (mapping, labels, filters) and align with 'InProgress' default

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/contracts/[id]/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/contracts/[id]/page.tsx
@@ -34,7 +34,7 @@ const contractStatusMap: Record<string, { label: string; className: string }> =
   {
     NotStarted: {
       label: "Chưa bắt đầu",
-      className: "bg-gray-200 text-gray-700",
+      className: "bg-gray-100 text-gray-600",
     },
     PreparingDelivery: {
       label: "Chuẩn bị giao",
@@ -42,13 +42,24 @@ const contractStatusMap: Record<string, { label: string; className: string }> =
     },
     InProgress: {
       label: "Đang thực hiện",
-      className: "bg-yellow-100 text-yellow-800",
+      className: "bg-green-100 text-green-700",
+    },
+    PartialCompleted: {
+      label: "Hoàn thành một phần",
+      className: "bg-yellow-100 text-yellow-700",
     },
     Completed: {
       label: "Hoàn thành",
-      className: "bg-green-100 text-green-700",
+      className: "bg-blue-100 text-blue-700",
     },
-    Cancelled: { label: "Đã huỷ", className: "bg-red-100 text-red-700" },
+    Cancelled: {
+      label: "Đã huỷ",
+      className: "bg-red-100 text-red-700",
+    },
+    Expired: {
+      label: "Quá hạn",
+      className: "bg-orange-100 text-orange-700",
+    },
   };
 
 export default function ContractDetailPage() {

--- a/DakLakCoffeeSupplyChain/src/components/contracts/FilterContractStatusPanel.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/contracts/FilterContractStatusPanel.tsx
@@ -25,7 +25,14 @@ export default function FilterContractStatusPanel({
         onClick={() => setSelectedStatus(null)}
       />
 
-      {Object.entries(ContractStatusMap).map(([key, { label, color, icon }]) => (
+      {/* Chỉ hiển thị các trạng thái cần thiết */}
+      {[
+        { key: "NotStarted", ...ContractStatusMap.NotStarted },
+        { key: "InProgress", ...ContractStatusMap.InProgress },
+        { key: "Completed", ...ContractStatusMap.Completed },
+        { key: "Cancelled", ...ContractStatusMap.Cancelled },
+        { key: "Expired", ...ContractStatusMap.Expired },
+      ].map(({ key, label, color, icon }) => (
         <FilterBadge
           key={key}
           icon={icon}


### PR DESCRIPTION
## ☕ Feature: Manager – Contract status handling improvements

### 📌 Objective
Align the **Contract** UI with the new backend default status (**InProgress**) and improve status mapping, labels, and filters across the manager workflow (create, edit, detail, and list/filter).

---

### ✅ Key Changes
- Update **status mapping** to include/align `InProgress` as the default state.
- Refresh **status labels/badges** in detail and form views (VN labels e.g., “Đang thực hiện”).
- Improve **FilterContractStatusPanel** to reflect the updated set/order of statuses.
- Ensure **create/edit** flows preserve or override status as intended (no unintended resets).
- Minor UI copy and icon consistency improvements for status badges.

---

### 📁 Affected Files
- `DakLakCoffeeSupplyChain/src/app/dashboard/manager/contracts/[id]/page.tsx`
- `DakLakCoffeeSupplyChain/src/components/contracts/ContractForm.tsx`
- `DakLakCoffeeSupplyChain/src/components/contracts/FilterContractStatusPanel.tsx`

---

### 🧪 How to Test
1. Navigate:
   - Detail: `/dashboard/manager/contracts/[id]`
   - Create: `/dashboard/manager/contracts/create`
   - Edit: `/dashboard/manager/contracts/[id]/edit`
2. Verify:
   - **Create** a contract without setting `Status` → UI shows **InProgress** after create.
   - **Edit** an existing contract → status persists and updates correctly when changed.
   - **Filter** contracts by status in list views → results match the selected status.
   - Status **badges/labels** match the mapping (e.g., InProgress → “Đang thực hiện”).

---

### 🧪 Test Cases
- [x] Create without status → defaults to **InProgress** and displays correct label.
- [x] Edit status from **InProgress** → **Completed/Cancelled** → persists and reflects in detail.
- [x] Filter by **InProgress** returns only matching contracts.
- [x] Invalid/unknown status (simulated) → falls back to a safe label (or hidden).
- [x] No regressions in submit/validation flows for ContractForm.

---

### 🔍 Notes
- Ensure FE constants/i18n include `InProgress` with VN label “Đang thực hiện”.
- Keep parity with BE enums to avoid drift; no routing changes.
- If other modules consume status constants, confirm they already include `InProgress`.

---

### 🔗 Related
- Module: `Contract`
- Role: `BusinessManager`

---

### ☑️ Checklist (before PR)
- [ ] Covered typical/edge status transitions
- [ ] No console errors/warnings
- [ ] Commit message & description are clear
