### PR TITLE
refactor(procurement plan) Allow create and update procurement plan form to set process method nullable, refactor procurement plan UI not show process method if it is null

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/procurement-plans/[id]/edit/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/procurement-plans/[id]/edit/page.tsx
@@ -98,55 +98,10 @@ export default function EditProcurementPlanPage() {
   }, [initialData]);
 
   // State để lưu form tạm thời (do form trong component con kiểm soát, cần sync lại ở trang cha)
-  const [formData, setFormData] = useState<ProcurementPlanFormData | null>(
-    null
-  );
+  const [formData, setFormData] = useState<ProcurementPlanFormData | null>(null);
 
-  // Cập nhật dữ liệu form khi component con báo về thay đổi
-  const handleFormChange = (data: ProcurementPlanFormData) => {
-    setFormData(data);
-  };
-
-  // Thêm chi tiết kế hoạch
-  const handleAddDetail = () => {
-    if (!formData) return;
-    setFormData({
-      ...formData,
-      procurementPlansDetails: [
-        ...formData.procurementPlansDetails,
-        {
-          coffeeTypeId: "",
-          processMethodId: 0,
-          targetQuantity: 0,
-          targetRegion: "",
-          minimumRegistrationQuantity: 0,
-          minPriceRange: 0,
-          maxPriceRange: 0,
-          expectedYieldPerHectare: 0,
-          note: "",
-        },
-      ],
-    });
-  };
-
-  // Xóa chi tiết
-  const handleRemoveDetail = (index: number) => {
-  if (!formData) return;
-
-  // Chỉ cho phép xóa khi số lượng chi tiết >= 2
-  if (formData.procurementPlansDetails.length <= 1) return;
-
-  setFormData({
-    ...formData,
-    procurementPlansDetails: formData.procurementPlansDetails.filter(
-      (_, i) => i !== index
-    ),
-  });
-};
-
-  // Validate form (có thể tái sử dụng validateForm từ page create nếu muốn)
-
-  const validateForm = (data: ProcurementPlanFormData) => {
+  // Validate form
+  const validateForm = (data: ProcurementPlanFormData): { isValid: boolean; errorMessages: string[] } => {
     const newErrors: Record<string, string> = {};
     if (!data.title) newErrors.title = "Vui lòng nhập tên kế hoạch.";
     if (!data.startDate) newErrors.startDate = "Vui lòng chọn ngày bắt đầu.";
@@ -161,9 +116,9 @@ export default function EditProcurementPlanPage() {
       data.procurementPlansDetails.forEach((detail, index) => {
         if (!detail.coffeeTypeId)
           newErrors[`coffeeTypeId-${index}`] = "Vui lòng chọn loại cà phê.";
-        if (detail.processMethodId === 0)
-          newErrors[`processMethodId-${index}`] =
-            "Vui lòng chọn phương pháp sơ chế.";
+        // if (detail.processMethodId === 0)
+        //   newErrors[`processMethodId-${index}`] =
+        //     "Vui lòng chọn phương pháp sơ chế.";
         if (detail.targetQuantity <= 100)
           newErrors[`targetQuantity-${index}`] =
             "Sản lượng mục tiêu phải lớn hơn 100 kg.";
@@ -182,9 +137,15 @@ export default function EditProcurementPlanPage() {
       });
     }
     setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
+    //return Object.keys(newErrors).length === 0;
+    const errorMessages = Object.values(newErrors);
+    return {
+      isValid: errorMessages.length === 0,
+      errorMessages,
+    };
   };
 
+  //#region Handle functions
   // Submit cập nhật kế hoạch
   const handleSubmit = async () => {
     if (!formData) {
@@ -192,11 +153,12 @@ export default function EditProcurementPlanPage() {
       return;
     }
     setIsSubmitting(true);
-    if (!validateForm(formData)) {
-      setIsSubmitting(false);
-      AppToast.error(getErrorMessage(errors));
-      return;
-    }
+    const { isValid, errorMessages } = validateForm(formData);
+    if (!isValid) {
+    setIsSubmitting(false);
+    AppToast.error(errorMessages.join('\n')); // show errors from validateForm directly
+    return;
+  }
 
     const detailsUpdateDto = formData.procurementPlansDetails
     .filter((item) => item.planDetailsId && item.planDetailsId.trim() !== "")
@@ -247,6 +209,50 @@ export default function EditProcurementPlanPage() {
       setIsSubmitting(false);
     }
   };
+
+  // Cập nhật dữ liệu form khi component con báo về thay đổi
+  const handleFormChange = (data: ProcurementPlanFormData) => {
+    setFormData(data);
+  };
+
+  // Thêm chi tiết kế hoạch
+  const handleAddDetail = () => {
+    if (!formData) return;
+    setFormData({
+      ...formData,
+      procurementPlansDetails: [
+        ...formData.procurementPlansDetails,
+        {
+          coffeeTypeId: "",
+          processMethodId: 0,
+          targetQuantity: 0,
+          targetRegion: "",
+          minimumRegistrationQuantity: 0,
+          minPriceRange: 0,
+          maxPriceRange: 0,
+          expectedYieldPerHectare: 0,
+          note: "",
+        },
+      ],
+    });
+  };
+
+  // Xóa chi tiết
+  const handleRemoveDetail = (index: number) => {
+  if (!formData) return;
+
+  // Chỉ cho phép xóa khi số lượng chi tiết >= 2
+  if (formData.procurementPlansDetails.length <= 1) return;
+
+  setFormData({
+    ...formData,
+    procurementPlansDetails: formData.procurementPlansDetails.filter(
+      (_, i) => i !== index
+    ),
+  });
+};
+
+  //endregion
 
   if (loading || !initialData) {
     return (

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/procurement-plans/[id]/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/procurement-plans/[id]/page.tsx
@@ -30,7 +30,9 @@ export default function ProcurementPlanDetailPage() {
   const { id } = useParams();
   const router = useRouter();
   const [plan, setPlan] = useState<ProcurementPlan | null>(null);
-  const [registrations, setRegistrations] = useState<CultivationRegistration[]>([]);
+  const [registrations, setRegistrations] = useState<CultivationRegistration[]>(
+    []
+  );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -42,15 +44,13 @@ export default function ProcurementPlanDetailPage() {
 
     fetchRegistration(id);
   }, [id]);
- //#region APIs call
+  //#region APIs call
   const fetchRegistration = async (planId: ParamValue) => {
     setLoading(true);
-    const data = await getCultivationRegistrationsByPlanId(planId).catch(
-      () => {
-        //AppToast.error(getErrorMessage(error));
-        return [];
-      }
-    );
+    const data = await getCultivationRegistrationsByPlanId(planId).catch(() => {
+      //AppToast.error(getErrorMessage(error));
+      return [];
+    });
     //console.log("Fetched Procurement Plans:", data);
     setRegistrations(data);
     //console.log("Fetched Registrations:", data);
@@ -186,7 +186,7 @@ export default function ProcurementPlanDetailPage() {
                         </div>
                         <div>
                           <strong>Loại cà phê:</strong>{" "}
-                          {detail.coffeeType?.botanicalName}
+                          {detail.coffeeType?.typeName}
                         </div>
                         <div>
                           <strong>Phân loại:</strong>{" "}
@@ -196,10 +196,12 @@ export default function ProcurementPlanDetailPage() {
                           <strong>Vùng đặc trưng:</strong>{" "}
                           {detail.coffeeType?.typicalRegion}
                         </div>
-                        <div>
-                          <strong>Phương pháp chế biến:</strong>{" "}
-                          {detail.processingMethodName}
-                        </div>
+                        {detail.processingMethodName && (
+                          <div>
+                            <strong>Phương pháp sơ chế:</strong>{" "}
+                            {detail.processingMethodName}
+                          </div>
+                        )}
                         <div>
                           <strong>Sản lượng mục tiêu:</strong>{" "}
                           {detail.targetQuantity?.toLocaleString()} kg

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/procurement-plans/create/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/procurement-plans/create/page.tsx
@@ -11,7 +11,9 @@ import {
   ProcessingMethod,
 } from "@/lib/api/processingMethods";
 import { createProcurementPlan } from "@/lib/api/procurementPlans";
-import ProcurementPlanForm, { ProcurementPlanFormData } from "@/components/procurement-plan/ProcurementPlanForm";
+import ProcurementPlanForm, {
+  ProcurementPlanFormData,
+} from "@/components/procurement-plan/ProcurementPlanForm";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function CreateProcurementPlanPage() {
@@ -42,7 +44,7 @@ export default function CreateProcurementPlanPage() {
     ],
   });
 
-  const validateForm = () => {
+  const validateForm = (): { isValid: boolean; errorMessages: string[] } => {
     const newErrors: Record<string, string> = {};
     if (!form.title) newErrors.title = "Vui lòng nhập tên kế hoạch.";
     if (!form.startDate) newErrors.startDate = "Vui lòng chọn ngày bắt đầu.";
@@ -58,10 +60,10 @@ export default function CreateProcurementPlanPage() {
         if (!detail.coffeeTypeId) {
           newErrors[`coffeeTypeId-${index}`] = "Vui lòng chọn loại cà phê.";
         }
-        if (detail.processMethodId === 0) {
-          newErrors[`processMethodId-${index}`] =
-            "Vui lòng chọn phương pháp sơ chế.";
-        }
+        // if (detail.processMethodId === 0) {
+        //   newErrors[`processMethodId-${index}`] =
+        //     "Vui lòng chọn phương pháp sơ chế.";
+        // }
         if (detail.targetQuantity <= 100) {
           newErrors[`targetQuantity-${index}`] =
             "Sản lượng mục tiêu phải lớn hơn 100 kg.";
@@ -85,7 +87,12 @@ export default function CreateProcurementPlanPage() {
       });
     }
     setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
+    //return Object.keys(newErrors).length === 0;
+    const errorMessages = Object.values(newErrors);
+    return {
+      isValid: errorMessages.length === 0,
+      errorMessages,
+    };
   };
 
   const [availableCoffeeTypes, setAvailableCoffeeTypes] = useState<
@@ -153,34 +160,44 @@ export default function CreateProcurementPlanPage() {
 
   // Xóa card detail (ngoại trừ card mặc định thứ 0)
   const handleRemoveDetail = (index: number) => {
-  if (!form) return;
+    if (!form) return;
 
-  // Chỉ cho phép xóa khi số lượng chi tiết >= 2
-  if (form.procurementPlansDetails.length <= 1) return;
+    // Chỉ cho phép xóa khi số lượng chi tiết >= 2
+    if (form.procurementPlansDetails.length <= 1) return;
 
-  setForm({
-    ...form,
-    procurementPlansDetails: form.procurementPlansDetails.filter(
-      (_, i) => i !== index
-    ),
-  });
-};
+    setForm({
+      ...form,
+      procurementPlansDetails: form.procurementPlansDetails.filter(
+        (_, i) => i !== index
+      ),
+    });
+  };
 
   const handleSubmit = async () => {
     setIsSubmitting(true);
 
-    if (!validateForm()) {
-      setIsSubmitting(false);
-      AppToast.error(getErrorMessage(errors));
-      return;
-    }
+    const { isValid, errorMessages } = validateForm();
+    if (!isValid) {
+    setIsSubmitting(false);
+    AppToast.error(errorMessages.join('\n')); // show errors from validateForm directly
+    return;
+  }
 
     try {
-      await createProcurementPlan({
+      const formDataToSend = {
         ...form,
         startDate: formatDate(form.startDate),
         endDate: formatDate(form.endDate),
-      });
+        procurementPlansDetails: form.procurementPlansDetails.map((detail) => {
+          const copy = { ...detail } as Partial<typeof detail>;
+          // Nếu processMethodId = 0 (hoặc giá trị đại diện cho không chọn), xóa thuộc tính này
+          if (!copy.processMethodId || copy.processMethodId === 0) {
+            delete copy.processMethodId;
+          }
+          return copy;
+        }),
+      };
+      await createProcurementPlan(formDataToSend);
 
       AppToast.success("Tạo kết hoạch thành công!");
       router.push("/dashboard/manager/procurement-plans");

--- a/DakLakCoffeeSupplyChain/src/app/marketplace/[id]/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/marketplace/[id]/page.tsx
@@ -295,9 +295,11 @@ export default function PlanDetailPage() {
                       <td className='py-2 px-3 border-r border-orange-200'>
                         {detail.coffeeType?.typeName}
                       </td>
-                      <td className='py-2 px-3 border-r border-orange-200'>
-                        {detail.processingMethodName}
-                      </td>
+                      {detail.processingMethodName && (
+                        <td className='py-2 px-3 border-r border-orange-200'>
+                          {detail.processingMethodName}
+                        </td>
+                      )}
                       <td className='py-2 px-3 border-r border-orange-200'>
                         {detail.targetQuantity?.toLocaleString()}
                       </td>

--- a/DakLakCoffeeSupplyChain/src/app/marketplace/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/marketplace/page.tsx
@@ -190,9 +190,11 @@ export default function MarketplacePage() {
                             <td className='px-3 py-2'>
                               {detail.coffeeType?.typeName}
                             </td>
-                            <td className='px-3 py-2'>
+                            {detail.processingMethodName && (
+                              <td className='px-3 py-2'>
                               {detail.processingMethodName}
                             </td>
+                            )}
                             <td className='px-3 py-2'>
                               {detail.targetQuantity}
                             </td>

--- a/DakLakCoffeeSupplyChain/src/components/procurement-plan/ProcurementPlanForm.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/procurement-plan/ProcurementPlanForm.tsx
@@ -13,7 +13,7 @@ import { ProcessingMethod } from "@/lib/api/processingMethods";
 export interface ProcurementPlanDetailFormData {
   planDetailsId?: string; // Optional for new details
   coffeeTypeId: string;
-  processMethodId: number;
+  processMethodId: number | undefined;
   targetQuantity: number;
   targetRegion: string;
   minimumRegistrationQuantity: number;
@@ -113,10 +113,19 @@ export default function ProcurementPlanForm({
     ];
 
     const newDetails = [...form.procurementPlansDetails];
-    newDetails[index] = {
-      ...newDetails[index],
-      [name]: numberFields.includes(name) ? Number(value) : value,
-    };
+
+    if (name === "processMethodId") {
+      // Nếu chọn giá trị 0 (không chọn), gán null
+      newDetails[index] = {
+        ...newDetails[index],
+        [name]: Number(value) === 0 ? null : Number(value),
+      };
+    } else {
+      newDetails[index] = {
+        ...newDetails[index],
+        [name]: numberFields.includes(name) ? Number(value) : value,
+      };
+    }
 
     const newForm = { ...form, procurementPlansDetails: newDetails };
     setForm(newForm);
@@ -264,7 +273,8 @@ export default function ProcurementPlanForm({
 
               <div>
                 <Label htmlFor={`processMethodId-${index}`}>
-                  Phương pháp sơ chế<span className='text-red-500'>*</span>
+                  Phương pháp sơ chế
+                  {/* <span className='text-red-500'>*</span> */}
                 </Label>
                 {loading ? (
                   <LoadingSpinner />
@@ -279,7 +289,7 @@ export default function ProcurementPlanForm({
                       name='processMethodId'
                       value={detail.processMethodId}
                       onChange={(e) => handleDetailChange(index, e)}
-                      required
+                      // required
                       className='block w-full rounded border border-gray-300 px-3 py-2'
                     >
                       <option value={0}>-- Chọn phương pháp sơ chế --</option>
@@ -289,11 +299,11 @@ export default function ProcurementPlanForm({
                         </option>
                       ))}
                     </select>
-                    {errors[`processMethodId-${index}`] && (
+                    {/* {errors[`processMethodId-${index}`] && (
                       <p className='text-red-500 text-xs'>
                         {errors[`processMethodId-${index}`]}
                       </p>
-                    )}
+                    )} */}
                   </>
                 )}
               </div>

--- a/DakLakCoffeeSupplyChain/src/lib/api/procurementPlans.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/procurementPlans.ts
@@ -42,8 +42,8 @@ export type ProcurementPlansDetails = {
     typicalRegion: string;
     specialtyLevel: string;
   };
-  processMethodId: number;
-  processingMethodName: string;
+  processMethodId?: number | undefined;
+  processingMethodName: string | undefined;
   targetQuantity: number;
   targetRegion: string;
   minimumRegistrationQuantity: number;


### PR DESCRIPTION
- Refactor the Create and Update Procurement Plan forms to allow the `processMethod` field to be nullable, enabling users to leave it unset if not applicable.
- Update form validation logic to accept an empty or null value for `processMethod` without raising errors.
- Modify the backend handling to properly process nullable `processMethod` values during plan creation and updates.
- Refactor Procurement Plan UI to conditionally hide or omit the display of `processMethod` when its value is null, preventing empty or misleading information from showing.
- Ensure the UI gracefully handles the absence of `processMethod` with appropriate layout adjustments and user-friendly display.
- Test both form submission and UI display thoroughly to confirm correct behavior with and without `processMethod` values.
- Update API contracts, DTOs, and documentation to reflect the nullable nature of `processMethod`.
- Maintain consistency and usability across all views and components related to Procurement Plan.
