### PR TITLE
refactor(Farming commitment) Add guide for Farming commitment create and edit page

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/farming-commitments/[id]/edit/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/farming-commitments/[id]/edit/page.tsx
@@ -5,14 +5,21 @@ import { useRouter, useParams, useSearchParams } from "next/navigation";
 import { AppToast } from "@/components/ui/AppToast";
 import { getErrorMessage } from "@/lib/utils";
 import LoadingSpinner from "@/components/ui/LoadingSpinner";
+import { calculateEstimatedDeliveryDates } from "@/lib/helpers/dateHelpers";
 import { useAuthGuard } from "@/lib/auth/useAuthGuard";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   CultivationRegistration,
   getCultivationRegistrationById,
 } from "@/lib/api/cultivationRegistrations";
-import FarmingCommitmentForm, { FarmingCommitmentFormData } from "@/components/farming-commitments/FarmingCommitmentForm";
-import { getCommitmentById, updateFarmingCommitment } from "@/lib/api/farmingCommitments";
+import FarmingCommitmentForm, {
+  FarmingCommitmentFormData,
+} from "@/components/farming-commitments/FarmingCommitmentForm";
+import {
+  getCommitmentById,
+  updateFarmingCommitment,
+} from "@/lib/api/farmingCommitments";
+import FarmingCommitmentFormGuide from "@/components/farming-commitments/FarmingCommitmentFormGuide";
 
 function EditFarmmingCommitmentContent() {
   useAuthGuard(["manager"]);
@@ -191,7 +198,10 @@ function EditFarmmingCommitmentContent() {
     }
 
     const detailsUpdateDto = formData.farmingCommitmentDetails
-      .filter((item) => item.commitmentDetailId && item.commitmentDetailId.trim() !== "")
+      .filter(
+        (item) =>
+          item.commitmentDetailId && item.commitmentDetailId.trim() !== ""
+      )
       .map((item) => ({
         commitmentDetailId: item.commitmentDetailId,
         registrationDetailId: item.registrationDetailId,
@@ -228,25 +238,55 @@ function EditFarmmingCommitmentContent() {
   }
 
   return (
-    <div className='max-w-2xl mx-auto py-10 px-4'>
-      <Card>
-        <CardHeader>
-          <CardTitle>Chỉnh sửa cam kết</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <FarmingCommitmentForm
-            initialData={formData || initialData}
-            registration={registration || undefined}
-            loading={loading}
-            errors={errors}
-            isSubmitting={isSubmitting}
-            onChange={handleFormChange}
-            onSubmit={handleSubmit}
-            onAddDetail={handleAddDetail}
-            onRemoveDetail={handleRemoveDetail}
-          />
-        </CardContent>
-      </Card>
+    <div className='min-h-screen py-8'>
+      <div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
+        {/* Header */}
+        <div className='mb-8'>
+          <h1 className='text-3xl font-bold text-gray-900'>
+            Chỉnh sửa cam kết
+          </h1>
+          <p className='text-gray-600 mt-2'>
+            Cập nhật thông tin cam kết thu mua với nông hộ
+          </p>
+        </div>
+
+        {/* Main Content */}
+        <div className='flex flex-col lg:flex-row gap-8'>
+          {/* Sidebar with Guide */}
+          <aside className='lg:w-96 flex-shrink-0'>
+            <div className='sticky top-8'>
+              <FarmingCommitmentFormGuide />
+            </div>
+          </aside>
+
+          {/* Form Content */}
+          <div className='flex-1'>
+            <Card className='shadow-lg border-0 p-0'>
+              <CardHeader className='bg-gradient-to-r from-orange-600 to-orange-700 text-white px-6 py-6 m-0 rounded-t-xl'>
+                <CardTitle className='text-white text-2xl font-bold'>
+                  Thông tin cam kết
+                </CardTitle>
+                <p className='text-green-100 text-sm mt-1'>
+                  Cập nhật thông tin để chỉnh sửa cam kết thu mua
+                </p>
+              </CardHeader>
+              <CardContent className='p-6'>
+                <FarmingCommitmentForm
+                  initialData={formData || initialData}
+                  registration={registration || undefined}
+                  loading={loading}
+                  errors={errors}
+                  isSubmitting={isSubmitting}
+                  onChange={handleFormChange}
+                  onSubmit={handleSubmit}
+                  onAddDetail={handleAddDetail}
+                  onRemoveDetail={handleRemoveDetail}
+                />
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/farming-commitments/create/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/farming-commitments/create/page.tsx
@@ -2,51 +2,31 @@
 
 import { useEffect, useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
 import { useAuthGuard } from "@/lib/auth/useAuthGuard";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
 import { AppToast } from "@/components/ui/AppToast";
 import { getErrorMessage } from "@/lib/utils";
-import { FiTrash2 } from "react-icons/fi";
 import LoadingSpinner from "@/components/ui/LoadingSpinner";
 import { createFarmingCommitment } from "@/lib/api/farmingCommitments";
 import {
   CultivationRegistration,
   getCultivationRegistrationById,
 } from "@/lib/api/cultivationRegistrations";
-import { LoadingButton } from "@/components/ui/loadingProgress";
+import FarmingCommitmentFormGuide from "@/components/farming-commitments/FarmingCommitmentFormGuide";
+import FarmingCommitmentForm, { FarmingCommitmentFormData } from "@/components/farming-commitments/FarmingCommitmentForm";
+import { calculateEstimatedDeliveryDates } from "@/lib/helpers/dateHelpers";
 
 function CreateFarmingCommitmentContent() {
   useAuthGuard(["manager"]);
 
-  // const formatDate = (d: string) => new Date(d).toISOString().split("T")[0];
   const searchParams = useSearchParams();
   const paramRegistrationId = searchParams.get("registrationId") || "";
-  const paramRegistrationDetailId =
-    searchParams.get("registrationDetailId") || "";
-  const paramWantedPrice = searchParams.get("wantedPrice") || "0";
-  const paramEstimatedYield = searchParams.get("estimatedYield") || "0";
   const router = useRouter();
 
-  const [form, setForm] = useState({
+  const [form, setForm] = useState<FarmingCommitmentFormData>({
     commitmentName: "",
-    registrationId: "",
     note: "",
-    farmingCommitmentsDetailsCreateDtos: [
-      {
-        registrationDetailId: "",
-        confirmedPrice: 0,
-        advancePayment: 0,
-        committedQuantity: 0,
-        estimatedDeliveryStart: "",
-        estimatedDeliveryEnd: "",
-        note: "",
-        //contractDeliveryItemId: "",
-      },
-    ],
+    farmingCommitmentDetails: [],
   });
 
   const [loading, setLoading] = useState(true);
@@ -57,33 +37,40 @@ function CreateFarmingCommitmentContent() {
 
   useEffect(() => {
     if (paramRegistrationId) {
-      setForm((prev) => ({
-        ...prev,
-        registrationId: paramRegistrationId,
-        farmingCommitmentsDetailsCreateDtos: [
-          {
-            registrationDetailId: paramRegistrationDetailId,
-            confirmedPrice: Number(paramWantedPrice),
-            advancePayment: 0,
-            committedQuantity: Number(paramEstimatedYield),
-            estimatedDeliveryStart: "",
-            estimatedDeliveryEnd: "",
-            note: "",
-            //contractDeliveryItemId: "",
-          },
-        ],
-      }));
-
-      if (paramRegistrationId) fetchRegistration(paramRegistrationId);
+      fetchRegistration(paramRegistrationId);
     }
+  }, [paramRegistrationId]);
 
-    //fetchPlan(paramRegistrationId);
-  }, [
-    paramRegistrationId,
-    paramRegistrationDetailId,
-    paramWantedPrice,
-    paramEstimatedYield,
-  ]);
+  // Tự động điền form khi có dữ liệu registration
+  useEffect(() => {
+    if (registration && registration.cultivationRegistrationDetails.length > 0) {
+      const approvedDetails = registration.cultivationRegistrationDetails.filter(
+        (detail) => detail.status === "Approved"
+      );
+      
+      if (approvedDetails.length > 0) {
+        setForm((prev) => ({
+          ...prev,
+          farmingCommitmentDetails: approvedDetails.map((detail) => {
+            // Tính toán ngày giao hàng dự kiến
+            const { estimatedDeliveryStart, estimatedDeliveryEnd } = calculateEstimatedDeliveryDates(
+              detail.expectedHarvestEnd || ""
+            );
+            
+            return {
+              registrationDetailId: detail.cultivationRegistrationDetailId || "",
+              confirmedPrice: detail.wantedPrice || 0,
+              advancePayment: 0,
+              committedQuantity: detail.estimatedYield || 0,
+              estimatedDeliveryStart,
+              estimatedDeliveryEnd,
+              note: "",
+            };
+          }),
+        }));
+      }
+    }
+  }, [registration]);
 
   //#region API Calls
 
@@ -95,12 +82,6 @@ function CreateFarmingCommitmentContent() {
         return null;
       }
     );
-    if (data) {
-      data.cultivationRegistrationDetails =
-        data.cultivationRegistrationDetails.filter(
-          (detail) => detail.status === "Approved"
-        );
-    }
     setRegistration(data);
     console.log("Fetched Registration:", data);
     setLoading(false);
@@ -112,14 +93,11 @@ function CreateFarmingCommitmentContent() {
     if (!form.commitmentName) {
       newErrors.commitmentName = "Tên cam kết là bắt buộc.";
     }
-    if (!form.registrationId) {
-      newErrors.registrationId = "ID đăng ký là bắt buộc.";
-    }
-    if (form.farmingCommitmentsDetailsCreateDtos.length === 0) {
-      newErrors.farmingCommitmentsDetailsCreateDtos =
+    if (form.farmingCommitmentDetails.length === 0) {
+      newErrors.farmingCommitmentDetails =
         "Cần ít nhất một chi tiết cam kết.";
     } else {
-      form.farmingCommitmentsDetailsCreateDtos.forEach((detail, index) => {
+      form.farmingCommitmentDetails.forEach((detail, index) => {
         if (!detail.registrationDetailId) {
           newErrors[`registrationDetailId-${index}`] =
             "ID chi tiết đăng ký là bắt buộc.";
@@ -161,20 +139,15 @@ function CreateFarmingCommitmentContent() {
   };
 
   //#region Form Handlers
-  const handleChange = (
-    e: React.ChangeEvent<
-      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-    >
-  ) => {
-    const { name, value } = e.target;
-    setForm((prev) => ({ ...prev, [name]: value }));
+  const handleFormChange = (formData: FarmingCommitmentFormData) => {
+    setForm(formData);
   };
 
   const handleAddDetail = () => {
     setForm((prev) => ({
       ...prev,
-      farmingCommitmentsDetailsCreateDtos: [
-        ...prev.farmingCommitmentsDetailsCreateDtos,
+      farmingCommitmentDetails: [
+        ...prev.farmingCommitmentDetails,
         {
           registrationDetailId: "",
           confirmedPrice: 0,
@@ -183,67 +156,55 @@ function CreateFarmingCommitmentContent() {
           estimatedDeliveryStart: "",
           estimatedDeliveryEnd: "",
           note: "",
-          //contractDeliveryItemId: "",
         },
       ],
     }));
   };
 
-  // Xóa card detail (ngoại trừ card mặc định thứ 0)
   const handleRemoveDetail = (index: number) => {
     setForm((prev) => {
-      const details = [...prev.farmingCommitmentsDetailsCreateDtos];
+      const details = [...prev.farmingCommitmentDetails];
       details.splice(index, 1);
-      return { ...prev, farmingCommitmentsDetailsCreateDtos: details };
+      return { ...prev, farmingCommitmentDetails: details };
     });
   };
 
-  const handleDetailChange = (
-    index: number,
-    key: string,
-    value: string | number
-  ) => {
-    setForm((prev) => {
-      const details = [...prev.farmingCommitmentsDetailsCreateDtos];
-      details[index] = { ...details[index], [key]: value };
-      return { ...prev, farmingCommitmentsDetailsCreateDtos: details };
-    });
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    //console.log("Submitting form:", form);
+  const handleSubmit = async () => {
     setIsSubmitting(true);
 
     const { isValid, errorMessages } = validateForm();
     if (!isValid) {
       setIsSubmitting(false);
-      AppToast.error(errorMessages.join("\n")); // show errors from validateForm directly
+      AppToast.error(errorMessages.join("\n"));
       return;
     }
 
     try {
-      await createFarmingCommitment(form);
+      // Convert form data to API format
+      const apiData = {
+        commitmentName: form.commitmentName,
+        registrationId: paramRegistrationId,
+        note: form.note,
+        farmingCommitmentsDetailsCreateDtos: form.farmingCommitmentDetails.map(detail => ({
+          registrationDetailId: detail.registrationDetailId,
+          confirmedPrice: detail.confirmedPrice,
+          advancePayment: detail.advancePayment,
+          committedQuantity: detail.committedQuantity,
+          estimatedDeliveryStart: detail.estimatedDeliveryStart,
+          estimatedDeliveryEnd: detail.estimatedDeliveryEnd,
+          note: detail.note,
+        })),
+      };
+
+      await createFarmingCommitment(apiData);
       AppToast.success("Tạo cam kết thành công!");
       router.push("/dashboard/manager/farming-commitments");
 
       setErrors({});
       setForm({
         commitmentName: "",
-        registrationId: "",
         note: "",
-        farmingCommitmentsDetailsCreateDtos: [
-          {
-            registrationDetailId: "",
-            confirmedPrice: 0,
-            advancePayment: 0,
-            committedQuantity: 0,
-            estimatedDeliveryStart: "",
-            estimatedDeliveryEnd: "",
-            note: "",
-            //contractDeliveryItemId: "",
-          },
-        ],
+        farmingCommitmentDetails: [],
       });
     } catch (error) {
       AppToast.error(getErrorMessage(error) || "Tạo cam kết thất bại.");
@@ -255,281 +216,53 @@ function CreateFarmingCommitmentContent() {
   //#endregion
 
   return (
-    <div className='max-w-2xl mx-auto py-10 px-4'>
-      <Card>
-        <CardHeader>
-          <CardTitle>Tạo cam kết mới</CardTitle>
-        </CardHeader>
-        <CardContent className='space-y-4'>
-          <div>
-            <Label htmlFor='commitmentName'>
-              Tên cam kết
-              <span className='text-red-500'>*</span>
-            </Label>
-            <Input
-              name='commitmentName'
-              value={form.commitmentName}
-              onChange={handleChange}
-              required
-            />
-            {errors[`commitmentName`] && (
-              <p className='text-red-500 text-xs'>{errors[`commitmentName`]}</p>
-            )}
+    <div className='min-h-screen py-8'>
+      <div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
+        {/* Header */}
+        <div className='mb-8'>
+          <h1 className='text-3xl font-bold text-gray-900'>Tạo cam kết mới</h1>
+          <p className='text-gray-600 mt-2'>
+            Tạo cam kết thu mua với nông hộ dựa trên đơn đăng ký đã được duyệt
+          </p>
+        </div>
+
+        {/* Main Content */}
+        <div className='flex flex-col lg:flex-row gap-8'>
+          {/* Sidebar with Guide */}
+          <aside className='lg:w-96 flex-shrink-0'>
+            <div className='sticky top-8'>
+              <FarmingCommitmentFormGuide />
+            </div>
+          </aside>
+
+          {/* Form Content */}
+          <div className='flex-1'>
+            <Card className='shadow-lg border-0 p-0'>
+              <CardHeader className='bg-gradient-to-r from-orange-600 to-orange-700 text-white px-6 py-6 m-0 rounded-t-xl'>
+                <CardTitle className='text-white text-2xl font-bold'>
+                  Thông tin cam kết
+                </CardTitle>
+                <p className='text-green-100 text-sm mt-1'>
+                  Điền đầy đủ thông tin để tạo cam kết thu mua
+                </p>
+              </CardHeader>
+              <CardContent className='p-6'>
+                <FarmingCommitmentForm
+                  initialData={form}
+                  registration={registration || undefined}
+                  loading={loading}
+                  errors={errors}
+                  isSubmitting={isSubmitting}
+                  onChange={handleFormChange}
+                  onSubmit={handleSubmit}
+                  onAddDetail={handleAddDetail}
+                  onRemoveDetail={handleRemoveDetail}
+                />
+              </CardContent>
+            </Card>
           </div>
-
-          <div>
-            <Label htmlFor='note'>Các điều khoản chung</Label>
-            <Textarea
-              id={"note"}
-              name='note'
-              value={form.note}
-              onChange={handleChange}
-            />
-          </div>
-
-          {/* Phần card chứa thông tin detail */}
-          {form.farmingCommitmentsDetailsCreateDtos.map((detail, index) => {
-            const alreadySelected = form.farmingCommitmentsDetailsCreateDtos
-              .map((d, i) => (i === index ? null : d.registrationDetailId))
-              .filter(Boolean);
-
-            const options = registration?.cultivationRegistrationDetails.filter(
-              (d) =>
-                !alreadySelected.includes(
-                  d.cultivationRegistrationDetailId ?? null
-                )
-            );
-            return (
-              <Card key={index} className='mb-4 border'>
-                <CardHeader className='flex justify-between items-center'>
-                  <CardTitle>Chi tiết cam kết #{index + 1}</CardTitle>
-                  {form.farmingCommitmentsDetailsCreateDtos.length > 1 && (
-                    <Button
-                      variant='destructive'
-                      size='sm'
-                      className='bg-red-100 text-red-800 hover:bg-red-200 cursor-pointer'
-                      onClick={() => handleRemoveDetail(index)}
-                    >
-                      <FiTrash2 className='mr-1' />
-                      Xóa
-                    </Button>
-                  )}
-                </CardHeader>
-                <CardContent className='space-y-3'>
-                  <div>
-                    <Label htmlFor={`registrationDetailId-${index}`}>
-                      Chi tiết đơn đăng ký (Chỉ chọn được những chi tiết đã
-                      duyệt)
-                      <span className='text-red-500'>*</span>
-                    </Label>
-                    {loading ? (
-                      <LoadingSpinner />
-                    ) : registration?.cultivationRegistrationDetails.length ===
-                      0 ? (
-                      <p className='text-red-500 text-sm italic'>
-                        Không có chi tiết đơn đăng ký nào đã duyệt để chọn
-                      </p>
-                    ) : (
-                      <select
-                        id={`registrationDetailId-${index}`}
-                        name='registrationDetailId'
-                        value={detail.registrationDetailId}
-                        onChange={(e) =>
-                          handleDetailChange(
-                            index,
-                            "registrationDetailId",
-                            e.target.value
-                          )
-                        }
-                        required
-                        className='block w-full rounded border border-gray-300 px-3 py-2 cursor-pointer'
-                        aria-label={`Chọn chi tiết đơn đăng ký cho chi tiết cam kết ${index + 1}`}
-                      >
-                        <option value=''>-- Chọn chi tiết --</option>
-                        {options?.map((registrationDetail) => (
-                          <option
-                            key={
-                              registrationDetail.cultivationRegistrationDetailId
-                            }
-                            value={
-                              registrationDetail.cultivationRegistrationDetailId
-                            }
-                            className='cursor-pointer'
-                          >
-                            {registrationDetail?.coffeeType}{" "}
-                            {" - Thu hoạch dự kiến: "}
-                            {registrationDetail?.estimatedYield} {"kg/ha"}{" "}
-                            {" - Giá mong muốn: "}
-                            {registrationDetail?.wantedPrice} {"VNĐ/kg"}
-                          </option>
-                        ))}
-                      </select>
-                    )}
-                  </div>
-
-                  <div>
-                    <Label htmlFor={`confirmedPrice-${index}`}>
-                      Giá cả thống nhất (VNĐ/kg)
-                      <span className='text-red-500'>*</span>
-                    </Label>
-                    <Input
-                      id={`confirmedPrice-${index}`}
-                      type='number'
-                      min={0}
-                      name='confirmedPrice'
-                      value={detail.confirmedPrice}
-                      onChange={(e) =>
-                        handleDetailChange(
-                          index,
-                          "confirmedPrice",
-                          Number(e.target.value)
-                        )
-                      }
-                      required
-                    />
-                    {errors[`confirmedPrice${index}`] && (
-                      <p className='text-red-500 text-xs'>
-                        {errors[`confirmedPrice${index}`]}
-                      </p>
-                    )}
-                  </div>
-
-                  <div>
-                    <Label htmlFor={`advancePayment-${index}`}>
-                      Số tiền tạm ứng cho nông dân (VNĐ/kg) (Có thể bỏ trống)
-                    </Label>
-                    <Input
-                      id={`advancePayment-${index}`}
-                      type='number'
-                      min={0}
-                      name='advancePayment'
-                      value={detail.advancePayment}
-                      onChange={(e) =>
-                        handleDetailChange(
-                          index,
-                          "advancePayment",
-                          Number(e.target.value)
-                        )
-                      }
-                    />
-                  </div>
-
-                  <div>
-                    <Label htmlFor={`committedQuantity-${index}`}>
-                      Sản lượng mục tiêu thống nhất (kg)
-                      <span className='text-red-500'>*</span>
-                    </Label>
-                    <Input
-                      id={`committedQuantity-${index}`}
-                      type='number'
-                      min={0}
-                      name='committedQuantity'
-                      value={detail.committedQuantity}
-                      onChange={(e) =>
-                        handleDetailChange(
-                          index,
-                          "committedQuantity",
-                          Number(e.target.value)
-                        )
-                      }
-                      required
-                    />
-                  </div>
-
-                  <div>
-                    <Label htmlFor={`estimatedDeliveryStart-${index}`}>
-                      Ngày giao hàng dự kiến bắt đầu{" "}
-                      <span className='text-red-500'>*</span>
-                    </Label>
-                    <Input
-                      id={`estimatedDeliveryStart-${index}`}
-                      type='date'
-                      name='estimatedDeliveryStart'
-                      value={detail.estimatedDeliveryStart}
-                      onChange={(e) =>
-                        handleDetailChange(
-                          index,
-                          "estimatedDeliveryStart",
-                          e.target.value
-                        )
-                      }
-                      required
-                    />
-                    {errors[`estimatedDeliveryStart-${index}`] && (
-                      <p className='text-red-500 text-xs'>
-                        {errors[`estimatedDeliveryStart-${index}`]}
-                      </p>
-                    )}
-                  </div>
-
-                  <div>
-                    <Label htmlFor={`estimatedDeliveryEnd-${index}`}>
-                      Ngày giao hàng dự kiến kết thúc{" "}
-                      <span className='text-red-500'>*</span>
-                    </Label>
-                    <Input
-                      id={`estimatedDeliveryEnd-${index}`}
-                      type='date'
-                      name='estimatedDeliveryEnd'
-                      value={detail.estimatedDeliveryEnd}
-                      onChange={(e) =>
-                        handleDetailChange(
-                          index,
-                          "estimatedDeliveryEnd",
-                          e.target.value
-                        )
-                      }
-                      required
-                    />
-                    {errors[`estimatedDeliveryEnd-${index}`] && (
-                      <p className='text-red-500 text-xs'>
-                        {errors[`estimatedDeliveryEnd-${index}`]}
-                      </p>
-                    )}
-                  </div>
-
-                  <div>
-                    <Label htmlFor={`note-${index}`}>
-                      Các điều khoản cụ thể
-                      <span className='text-red-500'>*</span>
-                    </Label>
-                    <Textarea
-                      id={`note-${index}`}
-                      name='note'
-                      value={detail.note}
-                      onChange={(e) =>
-                        handleDetailChange(index, "note", e.target.value)
-                      }
-                    />
-                  </div>
-                </CardContent>
-              </Card>
-            );
-          })}
-
-          <div className='flex justify-start mb-6'>
-            <Button
-              type='button'
-              onClick={handleAddDetail}
-              className='px-4 py-2 border border-orange-500 text-orange-700 font-bold hover:bg-orange-500 bg-orange-50 hover:text-white transition'
-            >
-              + Thêm chi tiết cam kết
-            </Button>
-          </div>
-
-          <div className='flex justify-end'>
-            <LoadingButton
-              loading={isSubmitting}
-              type='submit'
-              variant='default'
-              onClick={handleSubmit}
-              disabled={isSubmitting}
-            >
-              Tạo cam kết
-            </LoadingButton>
-          </div>
-        </CardContent>
-      </Card>
+        </div>
+      </div>
     </div>
   );
 }

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/procurement-plans/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/procurement-plans/page.tsx
@@ -41,8 +41,6 @@ export default function BusinessProcurementPlansPage() {
   const pageSize = 10;
   const router = useRouter();
 
-
-
   useEffect(() => {
     fetchData();
     setIsLoading(false);

--- a/DakLakCoffeeSupplyChain/src/components/farming-commitments/FarmingCommitmentForm.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/farming-commitments/FarmingCommitmentForm.tsx
@@ -8,6 +8,7 @@ import { FiTrash2 } from "react-icons/fi";
 import LoadingSpinner from "@/components/ui/LoadingSpinner";
 import { LoadingButton } from "@/components/ui/loadingProgress";
 import { CultivationRegistration } from "@/lib/api/cultivationRegistrations";
+import { calculateEstimatedDeliveryDates } from "@/lib/helpers/dateHelpers";
 
 export interface FarmingCommitmentDetailsFormData {
   commitmentDetailId?: string | undefined;
@@ -54,17 +55,7 @@ export default function FarmingCommitmentForm({
     initialData || {
       commitmentName: "",
       note: "",
-      farmingCommitmentDetails: [
-        {
-          registrationDetailId: "",
-          confirmedPrice: 0,
-          advancePayment: 0,
-          committedQuantity: 0,
-          estimatedDeliveryStart: "",
-          estimatedDeliveryEnd: "",
-          note: "",
-        },
-      ],
+      farmingCommitmentDetails: [],
     }
   );
 
@@ -97,15 +88,42 @@ export default function FarmingCommitmentForm({
       "confirmedPrice",
       "advancePayment",
       "committedQuantity",
-      "estimatedDeliveryStart",
-      "estimatedDeliveryEnd",
     ];
 
     const newDetails = [...form.farmingCommitmentDetails];
-    newDetails[index] = {
-      ...newDetails[index],
-      [name]: numberFields.includes(name) ? Number(value) : value,
-    };
+    
+    // Nếu đang chọn registrationDetailId, tự động điền các giá trị khác
+    if (name === "registrationDetailId" && value && registration) {
+      const selectedDetail = registration.cultivationRegistrationDetails.find(
+        (d) => d.cultivationRegistrationDetailId === value
+      );
+      
+      if (selectedDetail) {
+        // Tính toán ngày giao hàng dự kiến
+        const { estimatedDeliveryStart, estimatedDeliveryEnd } = calculateEstimatedDeliveryDates(
+          selectedDetail.expectedHarvestEnd || ""
+        );
+        
+        newDetails[index] = {
+          ...newDetails[index],
+          [name]: value,
+          confirmedPrice: selectedDetail.wantedPrice || 0,
+          committedQuantity: selectedDetail.estimatedYield || 0,
+          estimatedDeliveryStart,
+          estimatedDeliveryEnd,
+        };
+      } else {
+        newDetails[index] = {
+          ...newDetails[index],
+          [name]: value,
+        };
+      }
+    } else {
+      newDetails[index] = {
+        ...newDetails[index],
+        [name]: numberFields.includes(name) ? Number(value) : value,
+      };
+    }
 
     const newForm = { ...form, farmingCommitmentDetails: newDetails };
     setForm(newForm);
@@ -153,7 +171,13 @@ export default function FarmingCommitmentForm({
           />
         </div>
 
-        {form.farmingCommitmentDetails.map((detail, index) => {
+        {form.farmingCommitmentDetails.length === 0 ? (
+          <div className='text-center py-8 text-gray-500'>
+            <p>Chưa có chi tiết cam kết nào.</p>
+            <p className='text-sm mt-1'>Vui lòng chờ dữ liệu được tải hoặc thêm chi tiết thủ công.</p>
+          </div>
+        ) : (
+          form.farmingCommitmentDetails.map((detail, index) => {
           const alreadySelected = form.farmingCommitmentDetails
             .map((d, i) => (i === index ? null : d.registrationDetailId))
             .filter(Boolean);
@@ -162,7 +186,7 @@ export default function FarmingCommitmentForm({
             (d) =>
               !alreadySelected.includes(
               d.cultivationRegistrationDetailId ?? null
-              ) && d.status !== "Rejected"
+              ) && d.status === "Approved"
             );
           return (
             <Card key={index} className='mb-4 border'>
@@ -188,8 +212,7 @@ export default function FarmingCommitmentForm({
                   </Label>
                   {loading ? (
                     <LoadingSpinner />
-                  ) : registration?.cultivationRegistrationDetails.length ===
-                    0 ? (
+                  ) : !options || options.length === 0 ? (
                     <p className='text-red-500 text-sm italic'>
                       Không có chi tiết đơn đăng ký nào đã duyệt để chọn
                     </p>
@@ -216,9 +239,9 @@ export default function FarmingCommitmentForm({
                           >
                             {registrationDetail?.coffeeType}{" "}
                             {" - Thu hoạch dự kiến: "}
-                            {registrationDetail?.estimatedYield} {"kg/ha"}{" "}
+                            {registrationDetail?.estimatedYield}{"kg"}{" "}
                             {" - Giá mong muốn: "}
-                            {registrationDetail?.wantedPrice} {"VNĐ/kg"}
+                            {registrationDetail?.wantedPrice}{"VNĐ/kg"}
                           </option>
                         ))}
                       </select>
@@ -342,7 +365,8 @@ export default function FarmingCommitmentForm({
               </CardContent>
             </Card>
           );
-        })}
+        })
+        )}
 
         <div className='flex justify-start mb-6'>
           <Button

--- a/DakLakCoffeeSupplyChain/src/components/farming-commitments/FarmingCommitmentFormGuide.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/farming-commitments/FarmingCommitmentFormGuide.tsx
@@ -1,0 +1,236 @@
+import {
+  Info,
+  FileText,
+  Calendar,
+  Package,
+  DollarSign,
+  Users,
+  Target,
+  AlertCircle,
+  CheckCircle,
+} from "lucide-react";
+
+interface FarmingCommitmentFormGuideProps {
+  className?: string;
+}
+
+export default function FarmingCommitmentFormGuide({
+  className = "",
+}: FarmingCommitmentFormGuideProps) {
+  return (
+    <div className={`bg-white rounded-xl shadow-sm p-6 space-y-6 ${className}`}>
+      <div className='flex items-center gap-3 pb-4 border-b border-gray-200'>
+        <Info className='w-5 h-5 text-green-600' />
+        <h3 className='text-lg font-semibold text-gray-900'>
+          Hướng dẫn điền form cam kết
+        </h3>
+      </div>
+
+      <div className='space-y-5'>
+        {/* Tên cam kết */}
+        <div className='flex gap-3'>
+          <div className='flex-shrink-0 w-8 h-8 bg-green-100 rounded-full flex items-center justify-center'>
+            <FileText className='w-4 h-4 text-green-600' />
+          </div>
+          <div>
+            <h4 className='font-medium text-gray-900 mb-1'>Tên cam kết</h4>
+            <p className='text-sm text-gray-600'>
+              Đặt tên rõ ràng cho cam kết thu mua. Ví dụ: &quot;Cam kết thu mua
+              cà phê Robusta vụ 2025&quot;
+            </p>
+          </div>
+        </div>
+
+        {/* Thông tin nông hộ */}
+        <div className='flex gap-3'>
+          <div className='flex-shrink-0 w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center'>
+            <Users className='w-4 h-4 text-blue-600' />
+          </div>
+          <div>
+            <h4 className='font-medium text-gray-900 mb-1'>
+              Các điều khoản chung
+            </h4>
+            <p className='text-sm text-gray-600'>
+              Các điều khoản chung cho toàn bộ các chi tiết cam kết.
+            </p>
+          </div>
+        </div>
+
+        {/* Kế hoạch thu mua */}
+        <div className='flex gap-3'>
+          <div className='flex-shrink-0 w-8 h-8 bg-purple-100 rounded-full flex items-center justify-center'>
+            <FileText className='w-4 h-4 text-purple-600' />
+          </div>
+          <div>
+            <h4 className='font-medium text-gray-900 mb-1'>
+              Chi tiết đơn đăng ký
+            </h4>
+            <p className='text-sm text-gray-600'>
+              Hệ thống sẽ tự động lấy các chi tiết đăng ký của nông dân đã được duyệt và tự điền vào đơn cam kết. Doanh
+              nghiệp có thể trên đó để tùy chỉnh lại.
+            </p>
+          </div>
+        </div>
+
+        {/* Chi tiết cam kết */}
+        <div className='flex gap-3'>
+          <div className='flex-shrink-0 w-8 h-8 bg-orange-100 rounded-full flex items-center justify-center'>
+            <Package className='w-4 h-4 text-orange-600' />
+          </div>
+          <div>
+            <h4 className='font-medium text-gray-900 mb-1'>Chi tiết cam kết</h4>
+            <p className='text-sm text-gray-600'>
+              Xác nhận sản lượng, giá cả và thời gian giao hàng cho từng loại cà
+              phê
+            </p>
+          </div>
+        </div>
+
+        {/* Giá cam kết */}
+        <div className='flex gap-3'>
+          <div className='flex-shrink-0 w-8 h-8 bg-yellow-100 rounded-full flex items-center justify-center'>
+            <DollarSign className='w-4 h-4 text-yellow-600' />
+          </div>
+          <div>
+            <h4 className='font-medium text-gray-900 mb-1'>
+              Giá cả thống nhất
+            </h4>
+            <p className='text-sm text-gray-600'>
+              Giá thu mua thỏa thuận với nông hộ (VNĐ/kg). Có thể khác với giá
+              trong kế hoạch.
+            </p>
+          </div>
+        </div>
+
+        {/* Số tiền tạm ứng cho nông dân */}
+        <div className='flex gap-3'>
+          <div className='flex-shrink-0 w-8 h-8 bg-yellow-100 rounded-full flex items-center justify-center'>
+            <DollarSign className='w-4 h-4 text-yellow-600' />
+          </div>
+          <div>
+            <h4 className='font-medium text-gray-900 mb-1'>
+              Số tiền tạm ứng cho nông dân
+            </h4>
+            <p className='text-sm text-gray-600'>
+              Có thể trả trước cho nông dân để họ đầu tư vào các nguyên vật liệu
+              cho mùa vụ. Mục này tùy chọn.
+            </p>
+          </div>
+        </div>
+
+        {/* Sản lượng cam kết */}
+        <div className='flex gap-3'>
+          <div className='flex-shrink-0 w-8 h-8 bg-teal-100 rounded-full flex items-center justify-center'>
+            <Target className='w-4 h-4 text-teal-600' />
+          </div>
+          <div>
+            <h4 className='font-medium text-gray-900 mb-1'>
+              Sản lượng mục tiêu thống nhất
+            </h4>
+            <p className='text-sm text-gray-600'>
+              Số lượng cà phê mà nông hộ cam kết cung cấp (kg). Có thể điều
+              chỉnh theo khả năng thực tế
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Thời gian giao hàng */}
+      <div className='flex gap-3'>
+        <div className='flex-shrink-0 w-8 h-8 bg-indigo-100 rounded-full flex items-center justify-center'>
+          <Calendar className='w-4 h-4 text-indigo-600' />
+        </div>
+        <div>
+          <h4 className='font-medium text-gray-900 mb-1'>
+            Thời gian giao hàng
+          </h4>
+          <p className='text-sm text-gray-600'>
+            Khoảng thời gian dự kiến nông hộ sẽ giao hàng. Hệ thống sẽ tự điền
+            cách 1 ngày dựa trên ngày dự kiến thu hoạch kết thúc từ chi tiết đơn
+            đăng ký của nông hộ. Nên phù hợp với mùa vụ thu hoạch.
+          </p>
+        </div>
+      </div>
+
+      {/* Lưu ý quan trọng */}
+      <div className='bg-amber-50 border border-amber-200 rounded-lg p-4'>
+        <div className='flex gap-2 items-start'>
+          <AlertCircle className='w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5' />
+          <div>
+            <h4 className='font-medium text-amber-800 mb-2'>
+              Lưu ý quan trọng
+            </h4>
+            <ul className='text-sm text-amber-700 space-y-1'>
+              <li>
+                • Cam kết sau khi được duyệt sẽ trở thành hợp đồng ràng buộc
+              </li>
+              <li>
+                • Đảm bảo thông tin chính xác về sản lượng và thời gian giao
+                hàng
+              </li>
+              <li>
+                • Giá cam kết phải phù hợp với thị trường và chất lượng cà phê
+              </li>
+              <li>• Thời gian giao hàng nên phù hợp với chu kỳ thu hoạch</li>
+              <li>• Kiểm tra kỹ thông tin nông hộ và kế hoạch thu mua</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      {/* Quy trình xử lý */}
+      <div className='bg-green-50 border border-green-200 rounded-lg p-4'>
+        <h4 className='font-medium text-green-800 mb-3'>
+          Quy trình xử lý cam kết
+        </h4>
+        <div className='space-y-2 text-sm text-green-700'>
+          <div className='flex gap-2'>
+            <span className='w-5 h-5 bg-green-200 rounded-full flex items-center justify-center text-xs font-medium'>
+              1
+            </span>
+            <span>Tạo cam kết (Pending)</span>
+          </div>
+          <div className='flex gap-2'>
+            <span className='w-5 h-5 bg-green-200 rounded-full flex items-center justify-center text-xs font-medium'>
+              2
+            </span>
+            <span>Nông hộ xác nhận cam kết</span>
+          </div>
+          <div className='flex gap-2'>
+            <span className='w-5 h-5 bg-green-200 rounded-full flex items-center justify-center text-xs font-medium'>
+              3
+            </span>
+            <span>Nông hộ có thể bắt đầu quy trình tạo mùa vụ</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Trạng thái cam kết */}
+      <div className='bg-blue-50 border border-blue-200 rounded-lg p-4'>
+        <h4 className='font-medium text-blue-800 mb-3'>
+          Các trạng thái cam kết
+        </h4>
+        <div className='space-y-2 text-sm text-blue-700'>
+          <div className='flex items-center gap-2'>
+            <div className='w-3 h-3 bg-blue-400 rounded-full'></div>
+            <span>
+              <strong>Pending:</strong> Đang chờ nông hộ xác nhận
+            </span>
+          </div>
+          <div className='flex items-center gap-2'>
+            <div className='w-3 h-3 bg-green-400 rounded-full'></div>
+            <span>
+              <strong>Approved:</strong> Đã được duyệt và thực hiện
+            </span>
+          </div>
+          <div className='flex items-center gap-2'>
+            <div className='w-3 h-3 bg-red-400 rounded-full'></div>
+            <span>
+              <strong>Rejected:</strong> Bị từ chối hoặc hủy bỏ
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/DakLakCoffeeSupplyChain/src/components/procurement-plan/ProcurementPlanFormGuide.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/procurement-plan/ProcurementPlanFormGuide.tsx
@@ -154,14 +154,27 @@ export default function ProcurementPlanFormGuide({ className = "" }: Procurement
           </div>
           <div className="flex gap-2">
             <span className="w-5 h-5 bg-blue-200 rounded-full flex items-center justify-center text-xs font-medium">3</span>
-            <span>Nông hộ đăng ký và cam kết sản lượng</span>
+            <span>Nông hộ đăng ký kế hoạch</span>
           </div>
           <div className="flex gap-2">
             <span className="w-5 h-5 bg-blue-200 rounded-full flex items-center justify-center text-xs font-medium">4</span>
-            <span>Kết thúc đăng ký và thực hiện thu mua</span>
+            <span>Duyệt đơn đăng ký và tạo đơn cam kết</span>
+          </div>
+          <div className="flex gap-2">
+            <span className="w-5 h-5 bg-blue-200 rounded-full flex items-center justify-center text-xs font-medium">5</span>
+            <span>Nông hộ chấp nhận hoặc từ chối cam kết</span>
+          </div>
+          <div className="flex gap-2">
+            <span className="w-5 h-5 bg-blue-200 rounded-full flex items-center justify-center text-xs font-medium">6</span>
+            <span>Kết thúc quy trình lập kế hoạch thu mua</span>
+          </div>
+          <div className="flex gap-2">
+            <span className="w-5 h-5 bg-blue-200 rounded-full flex items-center justify-center text-xs font-medium">7</span>
+            <span>Bắt đầu quy trình theo dõi tiến độ mùa vụ</span>
           </div>
         </div>
       </div>
     </div>
   );
 }
+

--- a/DakLakCoffeeSupplyChain/src/lib/helpers/dateHelpers.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/helpers/dateHelpers.ts
@@ -1,0 +1,34 @@
+/**
+ * Tính toán ngày giao hàng dự kiến dựa trên ngày thu hoạch
+ * @param expectedHarvestEnd - Ngày kết thúc thu hoạch dự kiến (ISO string)
+ * @returns Object chứa ngày giao hàng bắt đầu và kết thúc
+ */
+export function calculateEstimatedDeliveryDates(expectedHarvestEnd: string): {
+  estimatedDeliveryStart: string;
+  estimatedDeliveryEnd: string;
+} {
+  let estimatedDeliveryStart = "";
+  let estimatedDeliveryEnd = "";
+  
+  if (expectedHarvestEnd) {
+    try {
+      // Ngày giao hàng bắt đầu = ngày kế tiếp sau ngày kết thúc thu hoạch
+      const harvestEndDate = new Date(expectedHarvestEnd);
+      const deliveryStartDate = new Date(harvestEndDate);
+      deliveryStartDate.setDate(deliveryStartDate.getDate() + 1);
+      estimatedDeliveryStart = deliveryStartDate.toISOString().split('T')[0];
+      
+      // Ngày giao hàng kết thúc = ngày giao hàng bắt đầu + 1 ngày
+      const deliveryEndDate = new Date(deliveryStartDate);
+      deliveryEndDate.setDate(deliveryEndDate.getDate() + 1);
+      estimatedDeliveryEnd = deliveryEndDate.toISOString().split('T')[0];
+    } catch (error) {
+      console.error('Error calculating delivery dates:', error);
+    }
+  }
+  
+  return {
+    estimatedDeliveryStart,
+    estimatedDeliveryEnd,
+  };
+}


### PR DESCRIPTION
- Add a user guide or help section on the Farming Commitment Create and Edit pages to assist users with the process.
- Provide clear, concise instructions describing the purpose of the form, the meaning of each field, and any important business rules or validation criteria.
- Integrate tooltips, info icons, or expandable help panels near relevant form elements to offer contextual guidance without cluttering the UI.
- Ensure the guide is easy to access but non-intrusive, allowing users to consult it as needed.
- Consider including examples or best practice tips to help users enter accurate and complete information.
- Keep the language user-friendly and aligned with the target audience’s knowledge level.
- Make sure the guide is responsive and accessible on all device types, supporting keyboard navigation and screen readers.
- Update documentation as needed to reflect the guide content and inform support or training teams.
- Test the guide’s visibility and usefulness with user feedback and iterate accordingly.
