### PR TITLE
fix(i18n): add missing common.filterByStatus & common.allStatuses (en, vi) to common section; fix raw keys on Shipments filter panel

### DIFF
--- a/DakLakCoffeeSupplyChain/src/i18n/locales/en.json
+++ b/DakLakCoffeeSupplyChain/src/i18n/locales/en.json
@@ -1886,7 +1886,9 @@
     "totalSizeLimit": "Total file size ({{totalSizeMB}}MB) exceeds 50MB limit",
     "totalFilesLimit": "Total files ({{totalFiles}}) exceeds 10 files limit",
     "createProgressFailed": "Failed to create progress!",
-    "createProgressSuccess": "Progress created successfully!"
+    "createProgressSuccess": "Progress created successfully!",
+    "filterByStatus": "Filter by Status",
+    "allStatuses": "All Statuses"
   },
 
   "farmerBatchSelector": {

--- a/DakLakCoffeeSupplyChain/src/i18n/locales/vi.json
+++ b/DakLakCoffeeSupplyChain/src/i18n/locales/vi.json
@@ -1954,7 +1954,9 @@
     "totalSizeLimit": "Tổng kích thước files ({{totalSizeMB}}MB) vượt quá giới hạn 50MB",
     "totalFilesLimit": "Số lượng files ({{totalFiles}}) vượt quá giới hạn 10 files",
     "createProgressFailed": "Tạo tiến trình thất bại!",
-    "createProgressSuccess": "Tạo tiến trình thành công!"
+    "createProgressSuccess": "Tạo tiến trình thành công!",
+    "filterByStatus": "Lọc theo trạng thái",
+    "allStatuses": "Tất cả trạng thái"
   },
 
   "farmerBatchSelector": {


### PR DESCRIPTION
## ☕ Feature: Manager – Shipment Filter Panel (i18n Fix)

### 📌 Goal
Ensure proper bilingual translation (English/Vietnamese) for **shipment filter panel** labels.  
Previously, `common.filterByStatus` and `common.allStatuses` were shown as raw keys.

---

### ✅ Key Changes
- Added missing translations `common.filterByStatus` & `common.allStatuses` in both `en.json` and `vi.json`.
- Updated common section to centralize these keys for reuse.
- Fixed raw key issue on **Shipments page** filter dropdown.

---

### 📁 Affected Files
- `DakLakCoffeeSupplyChain/src/i18n/locales/en.json`
- `DakLakCoffeeSupplyChain/src/i18n/locales/vi.json`

---

### 🧪 How to Verify
1. Navigate to: `/dashboard/manager/shipments`
2. Check the **filter status panel**:
   - English UI should show: *Filter by Status* / *All Statuses*
   - Vietnamese UI should show: *Lọc theo trạng thái* / *Tất cả trạng thái*

---

### 🧪 Test Cases
- [x] ✅ Correct text displayed in **English** mode  
- [x] ✅ Correct text displayed in **Vietnamese** mode  
- [x] ❌ No more raw keys (`common.filterByStatus`, `common.allStatuses`) in UI  

---

### 🔍 Notes
- Only i18n translation keys were updated; no business logic was changed.  
- Centralized keys under `common` for consistency across pages.  

---

### 🔗 Related
- Module: **Shipments / Dashboard**
- Role: **Manager**

---

### ☑️ Pre-PR Checklist
- [x] Verified no console warnings for missing i18n keys  
- [x] Checked both EN & VI language switching  
- [x] Commit & description written clearly in English
