### PR TITLE
feat(i18n): add bilingual support (EN/VI) for BusinessManager contract list page & status filter panel

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/contracts/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/contracts/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { getAllContracts, ContractViewAllDto } from "@/lib/api/contracts";
@@ -21,6 +22,7 @@ import { softDeleteContract } from "@/lib/api/contracts";
 import { Tooltip } from "@/components/ui/tooltip";
 
 export default function ContractsPage() {
+  const { t } = useTranslation();
   const [contracts, setContracts] = useState<ContractViewAllDto[]>([]);
   const [search, setSearch] = useState("");
   const [selectedStatus, setSelectedStatus] = useState<string | null>(null);
@@ -79,30 +81,39 @@ export default function ContractsPage() {
     switch (status) {
       case "NotStarted":
         return {
-          label: "Chưa bắt đầu",
+          label: t("contracts.status.notStarted"),
           className: "bg-gray-100 text-gray-600",
         };
       case "PreparingDelivery":
         return {
-          label: "Chuẩn bị giao",
+          label: t("contracts.status.preparingDelivery"),
           className: "bg-purple-100 text-purple-700",
         };
       case "InProgress":
         return {
-          label: "Đang thực hiện",
+          label: t("contracts.status.inProgress"),
           className: "bg-green-100 text-green-700",
         };
       case "PartialCompleted":
         return {
-          label: "Hoàn thành một phần",
+          label: t("contracts.status.partialCompleted"),
           className: "bg-yellow-100 text-yellow-700",
         };
       case "Completed":
-        return { label: "Hoàn thành", className: "bg-blue-100 text-blue-700" };
+        return {
+          label: t("contracts.status.completed"),
+          className: "bg-blue-100 text-blue-700",
+        };
       case "Cancelled":
-        return { label: "Đã hủy", className: "bg-red-100 text-red-700" };
+        return {
+          label: t("contracts.status.cancelled"),
+          className: "bg-red-100 text-red-700",
+        };
       case "Expired":
-        return { label: "Quá hạn", className: "bg-orange-100 text-orange-700" };
+        return {
+          label: t("contracts.status.expired"),
+          className: "bg-orange-100 text-orange-700",
+        };
       default:
         return { label: status, className: "bg-gray-100 text-gray-600" };
     }
@@ -121,10 +132,10 @@ export default function ContractsPage() {
       );
       setShowDeleteDialog(false);
       setContractToDelete(null);
-      toast.success("Xóa hợp đồng thành công!");
+      toast.success(t("contracts.crud.success.delete"));
     } catch (error) {
       console.error("Lỗi khi xoá hợp đồng:", error);
-      toast.error("Xóa hợp đồng thất bại!");
+      toast.error(t("contracts.crud.error.delete"));
     }
   }
 
@@ -133,11 +144,11 @@ export default function ContractsPage() {
       <aside className="w-64 space-y-4">
         <div className="bg-white rounded-xl shadow-sm p-4 space-y-4">
           <h2 className="text-sm font-medium text-gray-700">
-            Tìm kiếm hợp đồng
+            {t("contracts.page.list.search.title")}
           </h2>
           <div className="relative">
             <Input
-              placeholder="Tìm kiếm..."
+              placeholder={t("contracts.page.list.search.placeholder")}
               value={search}
               onChange={(e) => {
                 setSearch(e.target.value);
@@ -161,7 +172,7 @@ export default function ContractsPage() {
             <div className="flex gap-4 items-center">
               <div className="flex flex-col">
                 <label className="text-sm font-medium text-gray-700">
-                  Từ ngày
+                  {t("contracts.page.list.filters.dateRange.fromDate")}
                 </label>
                 <Input
                   type="date"
@@ -176,7 +187,7 @@ export default function ContractsPage() {
               </div>
               <div className="flex flex-col">
                 <label className="text-sm font-medium text-gray-700">
-                  Đến ngày
+                  {t("contracts.page.list.filters.dateRange.toDate")}
                 </label>
                 <Input
                   type="date"
@@ -193,7 +204,7 @@ export default function ContractsPage() {
               className="bg-black text-white hover:bg-gray-800"
               onClick={() => router.push("/dashboard/manager/contracts/create")}
             >
-              + Tạo hợp đồng mới
+              {t("contracts.page.list.actions.createNew")}
             </Button>
           </div>
 
@@ -201,12 +212,24 @@ export default function ContractsPage() {
             <table className="min-w-full table-auto">
               <thead className="bg-gray-100 text-sm text-gray-600">
                 <tr>
-                  <th className="px-4 py-2 text-left">Số hợp đồng</th>
-                  <th className="px-4 py-2 text-left">Tên hợp đồng</th>
-                  <th className="px-4 py-2 text-left">Đối tác</th>
-                  <th className="px-4 py-2 text-center">Trạng thái</th>
-                  <th className="px-4 py-2 text-center">Thời gian</th>
-                  <th className="px-4 py-2 text-center">Hành động</th>
+                  <th className="px-4 py-2 text-left">
+                    {t("contracts.page.list.table.headers.contractNumber")}
+                  </th>
+                  <th className="px-4 py-2 text-left">
+                    {t("contracts.page.list.table.headers.contractTitle")}
+                  </th>
+                  <th className="px-4 py-2 text-left">
+                    {t("contracts.page.list.table.headers.partner")}
+                  </th>
+                  <th className="px-4 py-2 text-center">
+                    {t("contracts.page.list.table.headers.status")}
+                  </th>
+                  <th className="px-4 py-2 text-center">
+                    {t("contracts.page.list.table.headers.time")}
+                  </th>
+                  <th className="px-4 py-2 text-center">
+                    {t("contracts.page.list.table.headers.actions")}
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -216,7 +239,7 @@ export default function ContractsPage() {
                       colSpan={5}
                       className="text-center py-8 text-sm text-muted-foreground"
                     >
-                      Không tìm thấy hợp đồng nào
+                      {t("contracts.page.list.table.empty")}
                     </td>
                   </tr>
                 ) : (
@@ -258,7 +281,7 @@ export default function ContractsPage() {
                       </td>
                       <td className="px-4 py-2 whitespace-nowrap">
                         <div className="flex items-center gap-[2px]">
-                          <Tooltip content="Xem chi tiết">
+                          <Tooltip content={t("contracts.actions.view")}>
                             <Button
                               variant="ghost"
                               className="p-[2px] w-7 h-7"
@@ -271,7 +294,7 @@ export default function ContractsPage() {
                               <Eye className="w-4 h-4 text-blue-500" />
                             </Button>
                           </Tooltip>
-                          <Tooltip content="Chỉnh sửa">
+                          <Tooltip content={t("contracts.actions.edit")}>
                             <Button
                               variant="ghost"
                               className="p-[2px] w-7 h-7"
@@ -284,7 +307,7 @@ export default function ContractsPage() {
                               <Pencil className="w-4 h-4 text-yellow-500" />
                             </Button>
                           </Tooltip>
-                          <Tooltip content="Xoá">
+                          <Tooltip content={t("contracts.actions.delete")}>
                             <Button
                               variant="ghost"
                               className="p-[2px] w-7 h-7"
@@ -311,7 +334,7 @@ export default function ContractsPage() {
           <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center mt-4 px-4 py-2 bg-gray-50 border rounded-md text-sm text-gray-700">
             {/* Thông tin hiển thị hợp đồng */}
             <div className="text-sm text-gray-600">
-              Đang hiển thị{" "}
+              {t("contracts.page.list.table.pagination.showing")}{" "}
               <span className="font-medium">
                 {(currentPage - 1) * pageSize + 1}
               </span>
@@ -319,7 +342,8 @@ export default function ContractsPage() {
               <span className="font-medium">
                 {Math.min(currentPage * pageSize, filtered.length)}
               </span>{" "}
-              / {filtered.length} hợp đồng
+              {t("contracts.page.list.table.pagination.of")} {filtered.length}{" "}
+              {t("contracts.page.list.table.pagination.contracts")}
             </div>
 
             {/* Điều khiển phân trang */}
@@ -331,11 +355,12 @@ export default function ContractsPage() {
                 disabled={currentPage === 1}
                 onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
               >
-                ← Trước
+                {t("contracts.page.list.table.pagination.previous")}
               </Button>
               <span className="flex items-center px-2">
-                Trang <span className="mx-1 font-semibold">{currentPage}</span>{" "}
-                / {totalPages}
+                {t("contracts.page.list.table.pagination.page")}{" "}
+                <span className="mx-1 font-semibold">{currentPage}</span>{" "}
+                {t("contracts.page.list.table.pagination.of")} {totalPages}
               </span>
               <Button
                 variant="outline"
@@ -346,7 +371,7 @@ export default function ContractsPage() {
                   setCurrentPage((p) => Math.min(totalPages, p + 1))
                 }
               >
-                Sau →
+                {t("contracts.page.list.table.pagination.next")}
               </Button>
             </div>
           </div>
@@ -355,16 +380,16 @@ export default function ContractsPage() {
       <ConfirmDialog
         open={showDeleteDialog}
         onOpenChange={setShowDeleteDialog}
-        title="Xoá hợp đồng?"
+        title={t("contracts.crud.dialog.deleteItem.title")}
         description={
           <span>
-            Bạn có chắc chắn muốn xoá hợp đồng{" "}
-            <strong>{contractToDelete?.contractTitle}</strong>? Hành động này
-            không thể hoàn tác.
+            {t("contracts.crud.dialog.deleteItem.description", {
+              itemName: contractToDelete?.contractTitle,
+            })}
           </span>
         }
-        confirmText="Xóa"
-        cancelText="Hủy"
+        confirmText={t("contracts.crud.dialog.deleteItem.confirm")}
+        cancelText={t("contracts.crud.dialog.deleteItem.cancel")}
         onConfirm={handleDelete}
       />
     </div>

--- a/DakLakCoffeeSupplyChain/src/components/contracts/FilterContractStatusPanel.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/contracts/FilterContractStatusPanel.tsx
@@ -1,5 +1,9 @@
-import { ContractStatusMap, ContractStatusValue } from '@/lib/constants/contractStatus';
-import FilterBadge from '../crop-seasons/FilterBadge';
+import {
+  ContractStatusMap,
+  ContractStatusValue,
+} from "@/lib/constants/contractStatus";
+import FilterBadge from "../crop-seasons/FilterBadge";
+import { useTranslation } from "react-i18next";
 
 interface FilterContractStatusPanelProps {
   selectedStatus: string | null;
@@ -12,13 +16,17 @@ export default function FilterContractStatusPanel({
   setSelectedStatus,
   statusCounts,
 }: FilterContractStatusPanelProps) {
+  const { t } = useTranslation();
+
   return (
     <div className="bg-white rounded-xl shadow-sm p-4 space-y-3">
-      <h2 className="text-sm font-medium text-gray-700">Lọc theo trạng thái</h2>
+      <h2 className="text-sm font-medium text-gray-700">
+        {t("contracts.page.list.filters.title")}
+      </h2>
 
       <FilterBadge
         icon="📄"
-        label="Tất cả trạng thái"
+        label={t("contracts.page.list.filters.allStatuses")}
         count={Object.values(statusCounts).reduce((sum, val) => sum + val, 0)}
         color="orange"
         active={selectedStatus === null}
@@ -32,17 +40,30 @@ export default function FilterContractStatusPanel({
         { key: "Completed", ...ContractStatusMap.Completed },
         { key: "Cancelled", ...ContractStatusMap.Cancelled },
         { key: "Expired", ...ContractStatusMap.Expired },
-      ].map(({ key, label, color, icon }) => (
-        <FilterBadge
-          key={key}
-          icon={icon}
-          label={label}
-          color={color}
-          count={statusCounts[key as ContractStatusValue] || 0}
-          active={selectedStatus === key}
-          onClick={() => setSelectedStatus(key === selectedStatus ? null : key)}
-        />
-      ))}
+      ].map(({ key, color, icon }) => {
+        // Map key to correct translation key
+        const statusKeyMap: Record<string, string> = {
+          NotStarted: "notStarted",
+          InProgress: "inProgress",
+          Completed: "completed",
+          Cancelled: "cancelled",
+          Expired: "expired",
+        };
+
+        return (
+          <FilterBadge
+            key={key}
+            icon={icon}
+            label={t(`contracts.status.${statusKeyMap[key]}`)}
+            color={color}
+            count={statusCounts[key as ContractStatusValue] || 0}
+            active={selectedStatus === key}
+            onClick={() =>
+              setSelectedStatus(key === selectedStatus ? null : key)
+            }
+          />
+        );
+      })}
     </div>
   );
 }

--- a/DakLakCoffeeSupplyChain/src/i18n/locales/en.json
+++ b/DakLakCoffeeSupplyChain/src/i18n/locales/en.json
@@ -4056,5 +4056,179 @@
         "create": "Product updated successfully!"
       }
     }
+  },
+  "contracts": {
+    "contract": {
+      "title": "Contracts",
+      "description": "Manage coffee supply contracts"
+    },
+    "page": {
+      "list": {
+        "title": "Contract List",
+        "search": {
+          "title": "Search Contracts",
+          "placeholder": "Search...",
+          "description": "Search by contract code, contract title, partner"
+        },
+        "filters": {
+          "title": "Filter by Status",
+          "allStatuses": "All Statuses",
+          "dateRange": {
+            "fromDate": "From Date",
+            "toDate": "To Date"
+          }
+        },
+        "table": {
+          "headers": {
+            "contractNumber": "Contract Number",
+            "contractTitle": "Contract Title",
+            "partner": "Partner",
+            "status": "Status",
+            "time": "Time",
+            "actions": "Actions"
+          },
+          "empty": "No contracts found",
+          "pagination": {
+            "showing": "Showing",
+            "to": "to",
+            "of": "/",
+            "contracts": "contracts",
+            "page": "Page",
+            "previous": "← Previous",
+            "next": "Next →"
+          }
+        },
+        "actions": {
+          "createNew": "+ Create New Contract"
+        }
+      },
+      "create": {
+        "title": "Create New Contract",
+        "description": "Create new coffee supply contract"
+      },
+      "edit": {
+        "title": "Edit Contract",
+        "description": "Update contract information",
+        "loading": "Loading contract data...",
+        "notFound": "Contract not found with ID: {{id}}"
+      },
+      "detail": {
+        "title": "Contract Details",
+        "loading": "Loading contract data...",
+        "error": "Error loading contract",
+        "notFound": "Contract not found",
+        "itemList": "Item List",
+        "noItems": "No items found.",
+        "displaying": "Displaying",
+        "items": "items"
+      }
+    },
+    "status": {
+      "notStarted": "Not Started",
+      "preparingDelivery": "Preparing Delivery",
+              "inProgress": "In Progress",
+      "partialCompleted": "Partially Completed",
+      "completed": "Completed",
+      "cancelled": "Cancelled",
+      "expired": "Expired"
+    },
+    "form": {
+      "status": "Status"
+    },
+    "managerContract": {
+      "status": {
+        "notStarted": "Not Started",
+        "preparingDelivery": "Preparing Delivery",
+        "inProgress": "In Progress",
+        "partialCompleted": "Partially Completed",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "expired": "Expired"
+      },
+      "actions": {
+        "view": "View Details",
+        "edit": "Edit",
+        "delete": "Delete",
+        "deleteConfirm": {
+          "title": "Delete Contract?",
+          "description": "Are you sure you want to delete contract {{contractTitle}}? This action cannot be undone.",
+          "confirm": "Delete",
+          "cancel": "Cancel"
+        },
+        "download": "Download Contract",
+        "viewDirectly": "View Directly",
+        "addItem": "Add Item",
+        "action": "Action"
+      }
+    },
+    "crud": {
+      "form": {
+        "status": "Status",
+        "basicInfo": "Basic Information",
+        "contractNumber": "Contract Number",
+        "contractTitle": "Contract Title",
+        "seller": "Seller",
+        "buyer": "Buyer",
+        "deliveryRounds": "Delivery Rounds",
+        "totalQuantity": "Total Quantity",
+        "totalValue": "Total Value",
+        "startDate": "Start Date",
+        "endDate": "End Date",
+        "signedAt": "Signed Date",
+        "cancelReason": "Cancel Reason",
+        "createdAt": "Created Date",
+        "updatedAt": "Updated Date",
+        "contractFile": "Contract File",
+        "previewFile": "Preview File",
+        "coffeeType": "Coffee Type",
+        "quantity": "Quantity",
+        "unitPrice": "Unit Price",
+        "discount": "Discount",
+        "note": "Note",
+        "vndPerKg": "VND/kg"
+      },
+      "validation": {
+        "contractNumberRequired": "Please enter contract number",
+        "contractTitleRequired": "Please enter contract title",
+        "buyerRequired": "Please select buyer partner",
+        "startDateRequired": "Please select start date",
+        "endDateRequired": "Please select end date",
+        "endDateAfterStartDate": "End date must be after start date",
+        "quantityRequired": "Please enter quantity",
+        "quantityPositive": "Quantity must be greater than 0",
+        "unitPriceRequired": "Please enter unit price",
+        "unitPricePositive": "Unit price must be greater than 0"
+      },
+      "success": {
+        "create": "Contract created successfully!",
+        "update": "Contract updated successfully!",
+        "delete": "Contract deleted successfully!"
+      },
+      "error": {
+        "create": "Failed to create contract!",
+        "update": "Failed to update contract!",
+        "delete": "Failed to delete contract!"
+      },
+      "dialog": {
+        "deleteItem": {
+          "title": "Delete Item?",
+          "description": "Are you sure you want to delete item {{itemName}} from the contract? This action cannot be undone.",
+          "confirm": "Delete",
+          "cancel": "Cancel"
+        }
+      }
+    },
+    "form": {
+      "status": "Status"
+    },
+    "actions": {
+      "view": "View Details",
+      "edit": "Edit",
+      "delete": "Delete",
+      "download": "Download Contract",
+      "viewDirectly": "View Directly",
+      "addItem": "Add Item",
+      "action": "Action"
+    }
   }
 }

--- a/DakLakCoffeeSupplyChain/src/i18n/locales/vi.json
+++ b/DakLakCoffeeSupplyChain/src/i18n/locales/vi.json
@@ -4092,5 +4092,179 @@
         "create": "Cập nhật sản phẩm giao thành công!"
       }
     }
+  },
+  "contracts": {
+    "contract": {
+      "title": "Hợp đồng",
+      "description": "Quản lý hợp đồng cung cấp cà phê"
+    },
+    "page": {
+      "list": {
+        "title": "Danh sách hợp đồng",
+        "search": {
+          "title": "Tìm kiếm hợp đồng",
+          "placeholder": "Tìm kiếm...",
+          "description": "Tìm kiếm theo mã hợp đồng, tên hợp đồng, đối tác"
+        },
+        "filters": {
+          "title": "Lọc theo trạng thái",
+          "allStatuses": "Tất cả trạng thái",
+          "dateRange": {
+            "fromDate": "Từ ngày",
+            "toDate": "Đến ngày"
+          }
+        },
+        "table": {
+          "headers": {
+            "contractNumber": "Số hợp đồng",
+            "contractTitle": "Tên hợp đồng",
+            "partner": "Đối tác",
+            "status": "Trạng thái",
+            "time": "Thời gian",
+            "actions": "Hành động"
+          },
+          "empty": "Không tìm thấy hợp đồng nào",
+          "pagination": {
+            "showing": "Đang hiển thị",
+            "to": "đến",
+            "of": "/",
+            "contracts": "hợp đồng",
+            "page": "Trang",
+            "previous": "← Trước",
+            "next": "Sau →"
+          }
+        },
+        "actions": {
+          "createNew": "+ Tạo hợp đồng mới"
+        }
+      },
+      "create": {
+        "title": "Tạo hợp đồng mới",
+        "description": "Tạo hợp đồng cung cấp cà phê mới"
+      },
+      "edit": {
+        "title": "Chỉnh sửa hợp đồng",
+        "description": "Cập nhật thông tin hợp đồng",
+        "loading": "Đang tải dữ liệu hợp đồng...",
+        "notFound": "Không tìm thấy hợp đồng với ID: {{id}}"
+      },
+      "detail": {
+        "title": "Chi tiết hợp đồng",
+        "loading": "Đang tải dữ liệu hợp đồng...",
+        "error": "Lỗi tải hợp đồng",
+        "notFound": "Không tìm thấy hợp đồng",
+        "itemList": "Danh sách mặt hàng",
+        "noItems": "Không có mặt hàng nào.",
+        "displaying": "Đang hiển thị",
+        "items": "mặt hàng"
+      }
+    },
+    "status": {
+      "notStarted": "Chưa bắt đầu",
+      "preparingDelivery": "Chuẩn bị giao",
+      "inProgress": "Đang thực hiện",
+      "partialCompleted": "Hoàn thành một phần",
+      "completed": "Hoàn thành",
+      "cancelled": "Đã hủy",
+      "expired": "Quá hạn"
+    },
+    "form": {
+      "status": "Trạng thái"
+    },
+    "managerContract": {
+      "status": {
+        "notStarted": "Chưa bắt đầu",
+        "preparingDelivery": "Chuẩn bị giao",
+        "inProgress": "Đang thực hiện",
+        "partialCompleted": "Hoàn thành một phần",
+        "completed": "Hoàn thành",
+        "cancelled": "Đã hủy",
+        "expired": "Quá hạn"
+      },
+      "actions": {
+        "view": "Xem chi tiết",
+        "edit": "Chỉnh sửa",
+        "delete": "Xoá",
+        "deleteConfirm": {
+          "title": "Xoá hợp đồng?",
+          "description": "Bạn có chắc chắn muốn xoá hợp đồng {{contractTitle}}? Hành động này không thể hoàn tác.",
+          "confirm": "Xóa",
+          "cancel": "Hủy"
+        },
+        "download": "Tải xuống hợp đồng",
+        "viewDirectly": "Xem trực tiếp",
+        "addItem": "Thêm mặt hàng",
+        "action": "Hành động"
+      }
+    },
+    "crud": {
+      "form": {
+        "status": "Trạng thái",
+        "basicInfo": "Thông tin cơ bản",
+        "contractNumber": "Số hợp đồng",
+        "contractTitle": "Tên hợp đồng",
+        "seller": "Người bán",
+        "buyer": "Người mua",
+        "deliveryRounds": "Số đợt giao hàng",
+        "totalQuantity": "Tổng khối lượng",
+        "totalValue": "Tổng giá trị",
+        "startDate": "Ngày bắt đầu",
+        "endDate": "Ngày kết thúc",
+        "signedAt": "Ngày ký kết",
+        "cancelReason": "Lý do hủy",
+        "createdAt": "Ngày tạo",
+        "updatedAt": "Ngày cập nhật",
+        "contractFile": "Tệp hợp đồng",
+        "previewFile": "Xem trước tệp",
+        "coffeeType": "Loại cà phê",
+        "quantity": "Khối lượng",
+        "unitPrice": "Đơn giá",
+        "discount": "Giảm giá",
+        "note": "Ghi chú",
+        "vndPerKg": "VND/kg"
+      },
+      "validation": {
+        "contractNumberRequired": "Vui lòng nhập số hợp đồng",
+        "contractTitleRequired": "Vui lòng nhập tên hợp đồng",
+        "buyerRequired": "Vui lòng chọn đối tác mua",
+        "startDateRequired": "Vui lòng chọn ngày bắt đầu",
+        "endDateRequired": "Vui lòng chọn ngày kết thúc",
+        "endDateAfterStartDate": "Ngày kết thúc phải sau ngày bắt đầu",
+        "quantityRequired": "Vui lòng nhập số lượng",
+        "quantityPositive": "Số lượng phải lớn hơn 0",
+        "unitPriceRequired": "Vui lòng nhập đơn giá",
+        "unitPricePositive": "Đơn giá phải lớn hơn 0"
+      },
+      "success": {
+        "create": "Tạo hợp đồng thành công!",
+        "update": "Cập nhật hợp đồng thành công!",
+        "delete": "Xóa hợp đồng thành công!"
+      },
+      "error": {
+        "create": "Tạo hợp đồng thất bại!",
+        "update": "Cập nhật hợp đồng thất bại!",
+        "delete": "Xóa hợp đồng thất bại!"
+      },
+      "dialog": {
+        "deleteItem": {
+          "title": "Xoá mặt hàng?",
+          "description": "Bạn có chắc chắn muốn xoá mặt hàng {{itemName}} khỏi hợp đồng không? Hành động này không thể hoàn tác.",
+          "confirm": "Xoá",
+          "cancel": "Huỷ"
+        }
+      }
+    },
+    "form": {
+      "status": "Trạng thái"
+    },
+    "actions": {
+      "view": "Xem chi tiết",
+      "edit": "Chỉnh sửa",
+      "delete": "Xoá",
+      "download": "Tải xuống hợp đồng",
+      "viewDirectly": "Xem trực tiếp",
+      "addItem": "Thêm mặt hàng",
+      "action": "Hành động"
+    }
   }
 }


### PR DESCRIPTION
## ☕ Feature: BusinessManager – Contract List Bilingual Support

### 📌 Goal
Provide bilingual support (English & Vietnamese) for the **BusinessManager contract list page**.  
This ensures that contract list views and status filters are properly localized for both languages.

---

### ✅ Key Changes
- Added EN/VI translations for contract list page.
- Updated `FilterContractStatusPanel` to use i18n keys.
- Extended `en.json` and `vi.json` with missing contract-related keys.
- Ensured proper display of status filter labels in both languages.

---

### 📁 Affected Files
- `src/app/dashboard/manager/contracts/page.tsx`
- `src/components/contracts/FilterContractStatusPanel.tsx`
- `src/i18n/locales/en.json`
- `src/i18n/locales/vi.json`

---

### 🧪 How to Verify
1. Navigate to: `/dashboard/manager/contracts`
2. Test the following:
   - Switch language between **English** and **Vietnamese**.
   - Verify that all labels and filter options on the contract list page display correctly in both languages.
   - Ensure status filter panel shows proper translated text.

---

### 🧪 Test Cases
- [x] ✅ EN mode displays contract list and filter labels in English.  
- [x] ✅ VI mode displays contract list and filter labels in Vietnamese.  
- [x] ❌ No raw i18n keys visible in UI.  

---

### 🔍 Notes
- Used i18n common keys where applicable for consistency.
- Only UI/translation changes; no business logic affected.
- Responsive layout preserved.

---

### 🔗 Related
- Module: **Contracts / Dashboard**
- Role: **Business Manager**

---

### ☑️ Pre-PR Checklist
- [x] Verified EN/VI switch works on contract list page.
- [x] Checked no console warnings for missing keys.
- [x] Commit message & description are clear in English.
