### PR TITLE
style(product-ui, business-buyers-ui): show red * for required fields (ProductForm, BusinessBuyerForm)

### DIFF
--- a/DakLakCoffeeSupplyChain/src/components/business-buyers/BusinessBuyerForm.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/business-buyers/BusinessBuyerForm.tsx
@@ -64,7 +64,9 @@ export default function BusinessBuyerForm({ initialData, onSuccess }: Props) {
   if (!formData) {
     return (
       <div className="text-gray-500 text-center py-10">
-        {isEdit ? t('businessBuyers.edit.loading') : t('businessBuyers.create.form.creating')}
+        {isEdit
+          ? t("businessBuyers.edit.loading")
+          : t("businessBuyers.create.form.creating")}
       </div>
     );
   }
@@ -75,16 +77,19 @@ export default function BusinessBuyerForm({ initialData, onSuccess }: Props) {
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (!formData) {
-      toast.error(t('businessBuyers.create.validation.checkFormErrors'));
+      toast.error(t("businessBuyers.create.validation.checkFormErrors"));
       return;
     }
     const data: FormState = formData;
 
     if (!data.companyName?.trim())
-      return toast.error(t('businessBuyers.create.validation.companyNameRequired'));
-    if (!data.email?.trim()) return toast.error(t('businessBuyers.create.validation.emailRequired'));
+      return toast.error(
+        t("businessBuyers.create.validation.companyNameRequired")
+      );
+    if (!data.email?.trim())
+      return toast.error(t("businessBuyers.create.validation.emailRequired"));
     if (!data.phoneNumber?.trim())
-      return toast.error(t('businessBuyers.create.validation.phoneRequired'));
+      return toast.error(t("businessBuyers.create.validation.phoneRequired"));
 
     try {
       const normalizedWebsite =
@@ -98,7 +103,7 @@ export default function BusinessBuyerForm({ initialData, onSuccess }: Props) {
           website: normalizedWebsite,
         };
         await updateBusinessBuyer(payload);
-        toast.success(t('businessBuyers.edit.success'));
+        toast.success(t("businessBuyers.edit.success"));
         // Điều hướng về trang chi tiết buyer
         onSuccess();
       } else {
@@ -107,7 +112,7 @@ export default function BusinessBuyerForm({ initialData, onSuccess }: Props) {
           website: normalizedWebsite,
         };
         const newId = await createBusinessBuyer(payload);
-        toast.success(t('businessBuyers.create.success'));
+        toast.success(t("businessBuyers.create.success"));
         // Nếu backend trả về id, điều hướng sang trang chi tiết
         if (newId) {
           window.location.href = `/dashboard/manager/business-buyers/${newId}`;
@@ -118,7 +123,12 @@ export default function BusinessBuyerForm({ initialData, onSuccess }: Props) {
     } catch (err: any) {
       console.error("[BusinessBuyerForm] Error:", err);
       const message =
-        typeof err === "string" ? err : err?.message || (isEdit ? t('businessBuyers.edit.error') : t('businessBuyers.create.error'));
+        typeof err === "string"
+          ? err
+          : err?.message ||
+            (isEdit
+              ? t("businessBuyers.edit.error")
+              : t("businessBuyers.create.error"));
       toast.error(message);
     }
   }
@@ -129,95 +139,124 @@ export default function BusinessBuyerForm({ initialData, onSuccess }: Props) {
       className="max-w-4xl mx-auto bg-white border rounded-2xl shadow p-8 space-y-6"
     >
       <h2 className="text-2xl font-semibold text-center mb-4">
-        {isEdit ? t('businessBuyers.edit.title') : t('businessBuyers.create.title')}
+        {isEdit
+          ? t("businessBuyers.edit.title")
+          : t("businessBuyers.create.title")}
       </h2>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className="flex flex-col gap-2">
-          <label className="text-sm font-medium">{t('businessBuyers.create.form.companyName.label')}</label>
+          <label className="text-sm font-medium">
+            {t("businessBuyers.create.form.companyName.label")}{" "}
+            <span className="text-red-500">*</span>
+          </label>
           <Input
             value={formData.companyName}
             onChange={(e) => handleChange("companyName", e.target.value)}
             className="h-10"
-            placeholder={t('businessBuyers.create.form.companyName.placeholder')}
+            placeholder={t(
+              "businessBuyers.create.form.companyName.placeholder"
+            )}
           />
         </div>
         <div className="flex flex-col gap-2">
-          <label className="text-sm font-medium">{t('businessBuyers.create.form.contactPerson.label')}</label>
+          <label className="text-sm font-medium">
+            {t("businessBuyers.create.form.contactPerson.label")}
+          </label>
           <Input
             value={formData.contactPerson}
             onChange={(e) => handleChange("contactPerson", e.target.value)}
             className="h-10"
-            placeholder={t('businessBuyers.create.form.contactPerson.placeholder')}
+            placeholder={t(
+              "businessBuyers.create.form.contactPerson.placeholder"
+            )}
           />
         </div>
 
         <div className="flex flex-col gap-2">
-          <label className="text-sm font-medium">{t('businessBuyers.create.form.position.label')}</label>
+          <label className="text-sm font-medium">
+            {t("businessBuyers.create.form.position.label")}
+          </label>
           <Input
             value={formData.position}
             onChange={(e) => handleChange("position", e.target.value)}
             className="h-10"
-            placeholder={t('businessBuyers.create.form.position.placeholder')}
+            placeholder={t("businessBuyers.create.form.position.placeholder")}
           />
         </div>
         <div className="flex flex-col gap-2">
-          <label className="text-sm font-medium">{t('businessBuyers.create.form.taxCode.label')}</label>
+          <label className="text-sm font-medium">
+            {t("businessBuyers.create.form.taxCode.label")}
+          </label>
           <Input
             value={formData.taxId}
             onChange={(e) => handleChange("taxId", e.target.value)}
             className="h-10"
-            placeholder={t('businessBuyers.create.form.taxCode.placeholder')}
+            placeholder={t("businessBuyers.create.form.taxCode.placeholder")}
           />
         </div>
 
         <div className="md:col-span-2 flex flex-col gap-2">
-          <label className="text-sm font-medium">{t('businessBuyers.create.form.address.label')}</label>
+          <label className="text-sm font-medium">
+            {t("businessBuyers.create.form.address.label")}
+          </label>
           <Input
             value={formData.companyAddress}
             onChange={(e) => handleChange("companyAddress", e.target.value)}
             className="h-10"
-            placeholder={t('businessBuyers.create.form.address.placeholder')}
+            placeholder={t("businessBuyers.create.form.address.placeholder")}
           />
         </div>
 
         <div className="flex flex-col gap-2">
-          <label className="text-sm font-medium">{t('businessBuyers.create.form.email.label')}</label>
+          <label className="text-sm font-medium">
+            {t("businessBuyers.create.form.email.label")}{" "}
+            <span className="text-red-500">*</span>
+          </label>
           <Input
             type="email"
             value={formData.email}
             onChange={(e) => handleChange("email", e.target.value)}
             className="h-10"
-            placeholder={t('businessBuyers.create.form.email.placeholder')}
+            placeholder={t("businessBuyers.create.form.email.placeholder")}
           />
         </div>
         <div className="flex flex-col gap-2">
-          <label className="text-sm font-medium">{t('businessBuyers.create.form.phone.label')}</label>
+          <label className="text-sm font-medium">
+            {t("businessBuyers.create.form.phone.label")}{" "}
+            <span className="text-red-500">*</span>
+          </label>
           <Input
             value={formData.phoneNumber}
             onChange={(e) => handleChange("phoneNumber", e.target.value)}
             className="h-10"
-            placeholder={t('businessBuyers.create.form.phone.placeholder')}
+            placeholder={t("businessBuyers.create.form.phone.placeholder")}
           />
         </div>
 
         <div className="md:col-span-2 flex flex-col gap-2">
-          <label className="text-sm font-medium">{t('businessBuyers.create.form.website.label')}</label>
+          <label className="text-sm font-medium">
+            {t("businessBuyers.create.form.website.label")}
+          </label>
           <Input
             value={formData.website ?? ""}
             onChange={(e) => handleChange("website", e.target.value)}
             className="h-10"
-            placeholder={t('businessBuyers.create.form.website.placeholder')}
+            placeholder={t("businessBuyers.create.form.website.placeholder")}
           />
         </div>
       </div>
 
       <DialogFooter className="flex justify-between pt-4">
         <Button type="submit">
-          <h2>{isEdit ? t('businessBuyers.edit.form.submit') : t('businessBuyers.create.form.submit')}</h2>
+          <h2>
+            {isEdit
+              ? t("businessBuyers.edit.form.submit")
+              : t("businessBuyers.create.form.submit")}
+          </h2>
         </Button>
         <Button type="button" variant="outline" onClick={() => history.back()}>
-          {t('businessBuyers.create.form.cancel')}
+          {t("businessBuyers.create.form.cancel")}
         </Button>
       </DialogFooter>
     </form>

--- a/DakLakCoffeeSupplyChain/src/components/products/ProductForm.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/products/ProductForm.tsx
@@ -446,15 +446,22 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
         })
       );
     }
-    if (!data.batchId) return toast.error(t("products.form.validation.batchRequired"));
-    if (!data.inventoryId) return toast.error(t("products.form.validation.inventoryRequired"));
-    if (!data.coffeeTypeId) return toast.error(t("products.form.validation.coffeeTypeRequired"));
+    if (!data.batchId)
+      return toast.error(t("products.form.validation.batchRequired"));
+    if (!data.inventoryId)
+      return toast.error(t("products.form.validation.inventoryRequired"));
+    if (!data.coffeeTypeId)
+      return toast.error(t("products.form.validation.coffeeTypeRequired"));
     if (data.originRegion.length > 100)
       return toast.error(t("products.form.validation.originRegionTooLong"));
     if (data.originFarmLocation.length > 200)
-      return toast.error(t("products.form.validation.originFarmLocationTooLong"));
+      return toast.error(
+        t("products.form.validation.originFarmLocationTooLong")
+      );
     if (data.geographicalIndicationCode.length > 50)
-      return toast.error(t("products.form.validation.geographicalIndicationCodeTooLong"));
+      return toast.error(
+        t("products.form.validation.geographicalIndicationCodeTooLong")
+      );
     if (data.evaluatedQuality.length > 50)
       return toast.error(t("products.form.validation.evaluatedQualityTooLong"));
     if (
@@ -551,12 +558,16 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
   return (
     <form className="max-w-4xl mx-auto bg-white border rounded-2xl shadow p-8 space-y-6">
       <h2 className="text-2xl font-semibold text-center">
-        {isEdit ? t("products.form.title.edit") : t("products.form.title.create")}
+        {isEdit
+          ? t("products.form.title.edit")
+          : t("products.form.title.create")}
       </h2>
 
       {/* Basic Information */}
       <div className="space-y-4">
-        <h3 className="text-lg font-medium text-gray-900">{t("products.form.sections.basicInfo")}</h3>
+        <h3 className="text-lg font-medium text-gray-900">
+          {t("products.form.sections.basicInfo")}
+        </h3>
 
         <div
           className={`grid grid-cols-1 ${
@@ -565,7 +576,8 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
         >
           <div>
             <label className="block mb-1 text-sm font-medium">
-              {t("products.form.fields.productName")} *
+              {t("products.form.fields.productName")}{" "}
+              <span className="text-red-500">*</span>
             </label>
             <Input
               value={form.productName}
@@ -579,7 +591,8 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
           {isEdit && (
             <div>
               <label className="block mb-1 text-sm font-medium">
-                {t("products.form.fields.status")} *
+                {t("products.form.fields.status")}{" "}
+                <span className="text-red-500">*</span>
               </label>
               <select
                 className="w-full p-2 border rounded"
@@ -589,9 +602,10 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
                 }
               >
                 {Object.values(ProductStatus)
-                  .filter(status => 
-                    status !== ProductStatus.Draft && 
-                    status !== ProductStatus.InStock
+                  .filter(
+                    (status) =>
+                      status !== ProductStatus.Draft &&
+                      status !== ProductStatus.InStock
                   )
                   .map((s) => (
                     <option key={s} value={s}>
@@ -604,7 +618,9 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
         </div>
 
         <div>
-          <label className="block mb-1 text-sm font-medium">{t("products.form.fields.description")}</label>
+          <label className="block mb-1 text-sm font-medium">
+            {t("products.form.fields.description")}
+          </label>
           <Textarea
             placeholder={t("products.form.placeholders.description")}
             value={form.description}
@@ -617,12 +633,15 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
 
       {/* Pricing & Quantity */}
       <div className="space-y-4">
-        <h3 className="text-lg font-medium text-gray-900">{t("products.form.sections.pricingQuantity")}</h3>
+        <h3 className="text-lg font-medium text-gray-900">
+          {t("products.form.sections.pricingQuantity")}
+        </h3>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <div>
             <label className="block mb-1 text-sm font-medium">
-              {t("products.form.fields.unitPrice")} *
+              {t("products.form.fields.unitPrice")}{" "}
+              <span className="text-red-500">*</span>
             </label>
             <Input
               type="number"
@@ -648,7 +667,10 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
           </div>
 
           <div>
-            <label className="block mb-1 text-sm font-medium">{t("products.form.fields.quantityAvailable")} *</label>
+            <label className="block mb-1 text-sm font-medium">
+              {t("products.form.fields.quantityAvailable")}{" "}
+              <span className="text-red-500">*</span>
+            </label>
             <Input
               type="number"
               min={0}
@@ -659,7 +681,10 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
                 const value = e.target.value;
                 // Chỉ cho phép nhập số thập phân dương
                 if (value === "" || /^\d*\.?\d*$/.test(value)) {
-                  setField("quantityAvailable", value === "" ? "" : Number(value));
+                  setField(
+                    "quantityAvailable",
+                    value === "" ? "" : Number(value)
+                  );
                 }
               }}
               onKeyDown={(e) => {
@@ -691,7 +716,10 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
           </div>
 
           <div>
-            <label className="block mb-1 text-sm font-medium">{t("products.form.fields.unit")} *</label>
+            <label className="block mb-1 text-sm font-medium">
+              {t("products.form.fields.unit")}{" "}
+              <span className="text-red-500">*</span>
+            </label>
             <select
               className="w-full p-2 border rounded disabled:opacity-50 disabled:bg-gray-100 disabled:cursor-not-allowed disabled:text-gray-500"
               value={form.unit}
@@ -730,7 +758,8 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <div>
             <label className="block mb-1 text-sm font-medium">
-              {t("products.form.fields.batchId")} *
+              {t("products.form.fields.batchId")}{" "}
+              <span className="text-red-500">*</span>
             </label>
             <select
               className="w-full p-2 border rounded disabled:opacity-50 disabled:bg-gray-100 disabled:cursor-not-allowed disabled:text-gray-500"
@@ -738,7 +767,9 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
               onChange={(e) => setField("batchId", e.target.value)}
               disabled={loadingOptions || !canEditBatch()}
             >
-              <option value="">{t("products.form.selectOptions.selectBatch")}</option>
+              <option value="">
+                {t("products.form.selectOptions.selectBatch")}
+              </option>
               {batchOptions.map((batch) => (
                 <option key={batch.batchId} value={batch.batchId}>
                   {batch.batchCode}
@@ -767,7 +798,10 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
           </div>
 
           <div>
-            <label className="block mb-1 text-sm font-medium">{t("products.form.fields.inventoryId")} *</label>
+            <label className="block mb-1 text-sm font-medium">
+              {t("products.form.fields.inventoryId")}{" "}
+              <span className="text-red-500">*</span>
+            </label>
             <select
               className="w-full p-2 border rounded"
               value={form.inventoryId}
@@ -778,7 +812,9 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
               }}
               disabled={loadingOptions}
             >
-              <option value="">{t("products.form.selectOptions.selectInventory")}</option>
+              <option value="">
+                {t("products.form.selectOptions.selectInventory")}
+              </option>
               {inventoryOptions.map((inventory) => (
                 <option
                   key={inventory.inventoryId}
@@ -806,7 +842,8 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
 
           <div>
             <label className="block mb-1 text-sm font-medium">
-              {t("products.form.fields.coffeeTypeId")} *
+              {t("products.form.fields.coffeeTypeId")}{" "}
+              <span className="text-red-500">*</span>
             </label>
             <select
               className="w-full p-2 border rounded disabled:opacity-50 disabled:bg-gray-100 disabled:cursor-not-allowed disabled:text-gray-500"
@@ -814,7 +851,9 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
               onChange={(e) => setField("coffeeTypeId", e.target.value)}
               disabled={loadingOptions || !canEditCoffeeType()}
             >
-              <option value="">{t("products.form.selectOptions.selectCoffeeType")}</option>
+              <option value="">
+                {t("products.form.selectOptions.selectCoffeeType")}
+              </option>
               {coffeeTypes.map((type) => (
                 <option key={type.coffeeTypeId} value={type.coffeeTypeId}>
                   {type.typeName}
@@ -886,7 +925,9 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
               onChange={(e) =>
                 setField("geographicalIndicationCode", e.target.value)
               }
-              placeholder={t("products.form.placeholders.geographicalIndicationCode")}
+              placeholder={t(
+                "products.form.placeholders.geographicalIndicationCode"
+              )}
               maxLength={50}
             />
           </div>
@@ -949,7 +990,9 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
 
       {/* Approval */}
       <div className="space-y-4">
-        <h3 className="text-lg font-medium text-gray-900">{t("products.form.sections.approval")}</h3>
+        <h3 className="text-lg font-medium text-gray-900">
+          {t("products.form.sections.approval")}
+        </h3>
 
         <div>
           <label className="block mb-1 text-sm font-medium">
@@ -967,7 +1010,9 @@ export default function ProductForm({ initialData, onSuccess }: Props) {
 
       <DialogFooter className="flex justify-between pt-4">
         <Button type="submit" onClick={handleSubmit} disabled={saving}>
-          {isEdit ? t("products.form.actions.update") : t("products.form.actions.create")}
+          {isEdit
+            ? t("products.form.actions.update")
+            : t("products.form.actions.create")}
         </Button>
         <Button type="button" variant="outline" onClick={() => router.back()}>
           {t("products.form.actions.back")}


### PR DESCRIPTION
## ☕ Feature: Manager – Required Field Indicators (Product & Business Buyer)

### 📌 Objective
Improve form clarity for the **Manager** flow by showing a red asterisk on all **required fields** in Product and Business Buyer forms without changing validation logic.

---

### ✅ Main Changes
- Display a red `*` next to all required labels in **ProductForm** and **BusinessBuyerForm**.
- Normalize label/help-text spacing to avoid layout shifts.
- Minor accessibility touch-ups (consistent `aria-required` / `required` usage where applicable).
- Styling-only; no changes to business rules or APIs.

---

### 📁 Affected Files
- `DakLakCoffeeSupplyChain/src/components/business-buyers/BusinessBuyerForm.tsx`
- `DakLakCoffeeSupplyChain/src/components/products/ProductForm.tsx`

---

### 🧪 How to Test
1. Navigate to:
   - `/dashboard/manager/products` → **Create** and **Edit**
   - `/dashboard/manager/business-buyers` → **Create** and **Edit**
2. Verify:
   - Red asterisk appears on every required field label.
   - Submitting with missing required fields shows the same validation errors as before.
   - No layout jumping; labels and inputs remain aligned across breakpoints.

---

### 🧪 Test Cases
- [x] ✅ Required fields display a red asterisk.
- [x] ❌ Submitting with missing required inputs triggers validation errors.
- [x] ✅ No visual regressions on desktop/tablet/mobile.

---

### 🔍 Notes
- Uses existing UI from `@/components/ui` and Tailwind classes.
- Pure UI polish; no API calls or form schemas were changed.
- i18n keys are unaffected.

---

### 🔗 Related
- Module: `Products`, `Business Buyers`
- Role: `Manager`

---

### ☑️ Checklist (before creating PR)
- [ ] All test cases verified locally.
- [ ] No console errors or warnings.
- [ ] Clear commit message & PR description in English.
