### PR TITLE
feat(order-ui): set default status 'Đang xử lý' and highlight required fields with red *

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/business-buyers/[id]/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/business-buyers/[id]/page.tsx
@@ -49,7 +49,6 @@ export default function BusinessBuyerDetailsPage() {
         const data = await getBusinessBuyerById(id as string);
         setBuyer(data);
       } catch (e) {
-        console.error(e);
       } finally {
         setLoading(false);
       }

--- a/DakLakCoffeeSupplyChain/src/components/orders/OrderForm.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/orders/OrderForm.tsx
@@ -25,6 +25,7 @@ import {
   type ContractDeliveryBatchViewDetailsDto,
   getAllContractDeliveryBatches,
 } from "@/lib/api/contractDeliveryBatches";
+
 import { getProductOptions, type ProductOption } from "@/lib/api/products";
 import { OrderStatus } from "@/lib/constants/orderStatus";
 
@@ -95,7 +96,7 @@ export default function OrderForm({
     orderDate: undefined,
     actualDeliveryDate: undefined,
     note: "",
-    status: OrderStatus.Pending,
+    status: OrderStatus.Preparing,
     cancelReason: "",
     orderItems: [],
   });
@@ -115,7 +116,7 @@ export default function OrderForm({
       orderDate: orderDateStr,
       actualDeliveryDate: initialData.actualDeliveryDate ?? undefined, // đã yyyy-MM-dd
       note: initialData.note ?? "",
-      status: initialData.status ?? OrderStatus.Pending,
+      status: initialData.status ?? OrderStatus.Preparing,
       cancelReason: initialData.cancelReason ?? "",
       orderItems: (initialData.orderItems ?? []).map(
         (it): OrderItemRow => ({
@@ -167,7 +168,7 @@ export default function OrderForm({
         setProductOptions(products ?? []);
       } catch (e) {
         console.error(e);
-        toast.error(t('managerOrders.form.errors.loadDeliveryBatch'));
+        toast.error(t("managerOrders.form.errors.loadDeliveryBatch"));
       } finally {
         setLoadingOptions(false);
       }
@@ -189,7 +190,7 @@ export default function OrderForm({
         );
       } catch (e) {
         console.error(e);
-        toast.error(t('managerOrders.form.errors.loadDeliveryBatches'));
+        toast.error(t("managerOrders.form.errors.loadDeliveryBatches"));
       }
     })();
   }, [form.deliveryBatchId]);
@@ -343,27 +344,35 @@ export default function OrderForm({
     const clientErrors: Record<string, string> = {};
 
     if (!data.deliveryBatchId) {
-      clientErrors.deliveryBatchId = t('managerOrders.form.validation.selectDeliveryBatch');
+      clientErrors.deliveryBatchId = t(
+        "managerOrders.form.validation.selectDeliveryBatch"
+      );
     }
     if (!data.orderItems.length) {
-      clientErrors.orderItems = t('managerOrders.form.validation.addAtLeastOneItem');
+      clientErrors.orderItems = t(
+        "managerOrders.form.validation.addAtLeastOneItem"
+      );
     } else {
       data.orderItems.forEach((item, index) => {
         if (!item.contractDeliveryItemId) {
-          clientErrors[`orderItems.${index}.contractDeliveryItemId`] =
-            t('managerOrders.form.validation.selectDeliveryItem');
+          clientErrors[`orderItems.${index}.contractDeliveryItemId`] = t(
+            "managerOrders.form.validation.selectDeliveryItem"
+          );
         }
         if (!item.productId) {
-          clientErrors[`orderItems.${index}.productId`] =
-            t('managerOrders.form.validation.selectProduct');
+          clientErrors[`orderItems.${index}.productId`] = t(
+            "managerOrders.form.validation.selectProduct"
+          );
         }
         if (!(Number(item.quantity) > 0)) {
-          clientErrors[`orderItems.${index}.quantity`] =
-            t('managerOrders.form.validation.quantityRequired');
+          clientErrors[`orderItems.${index}.quantity`] = t(
+            "managerOrders.form.validation.quantityRequired"
+          );
         }
         if (!(Number(item.unitPrice) > 0)) {
-          clientErrors[`orderItems.${index}.unitPrice`] =
-            t('managerOrders.form.validation.unitPriceRequired');
+          clientErrors[`orderItems.${index}.unitPrice`] = t(
+            "managerOrders.form.validation.unitPriceRequired"
+          );
         }
       });
     }
@@ -373,15 +382,16 @@ export default function OrderForm({
       const actualDate = new Date(data.actualDeliveryDate);
       const orderDate = new Date(data.orderDate);
       if (actualDate < orderDate) {
-        clientErrors.actualDeliveryDate =
-          t('managerOrders.form.validation.actualDeliveryDateBeforeOrderDate');
+        clientErrors.actualDeliveryDate = t(
+          "managerOrders.form.validation.actualDeliveryDateBeforeOrderDate"
+        );
       }
     }
 
     // If there are client-side errors, display them and stop
     if (Object.keys(clientErrors).length > 0) {
       setFieldErrors(clientErrors);
-      toast.error(t('managerOrders.form.validation.checkFormErrors'));
+      toast.error(t("managerOrders.form.validation.checkFormErrors"));
       return;
     }
 
@@ -431,9 +441,9 @@ export default function OrderForm({
         const req = updateOrder(payload.orderId, payload);
         // Hiển thị toast theo trạng thái promise
         toast.promise(req, {
-          loading: t('managerOrders.form.actions.updating'),
-          success: t('managerOrders.form.actions.updateSuccess'),
-          error: t('managerOrders.form.actions.updateError'),
+          loading: t("managerOrders.form.actions.updating"),
+          success: t("managerOrders.form.actions.updateSuccess"),
+          error: t("managerOrders.form.actions.updateError"),
         });
         // Quan trọng: chờ promise gốc -> nếu fail sẽ nhảy vào catch, KHÔNG gọi onSuccess
         await req;
@@ -469,9 +479,9 @@ export default function OrderForm({
 
         const req = createOrder(payload);
         toast.promise(req, {
-          loading: t('managerOrders.form.actions.creating'),
-          success: t('managerOrders.form.actions.createSuccess'),
-          error: t('managerOrders.form.actions.createError'),
+          loading: t("managerOrders.form.actions.creating"),
+          success: t("managerOrders.form.actions.createSuccess"),
+          error: t("managerOrders.form.actions.createError"),
         });
         await req;
       }
@@ -609,11 +619,11 @@ export default function OrderForm({
           Object.keys(newFieldErrors).length > 0 ||
           newBusinessErrors.length > 0
         ) {
-          toast.error(t('managerOrders.form.errors.checkFormErrors'));
+          toast.error(t("managerOrders.form.errors.checkFormErrors"));
         }
       } else {
         // Xử lý lỗi khác - kiểm tra message trực tiếp
-        let errorMessage = t('managerOrders.form.errors.saveOrderError');
+        let errorMessage = t("managerOrders.form.errors.saveOrderError");
 
         if (err && typeof err === "object" && "message" in err) {
           const message = String(err.message);
@@ -621,13 +631,14 @@ export default function OrderForm({
           // Kiểm tra các lỗi nghiệp vụ cụ thể
           if (message.includes("Lô giao hàng này đã có đơn hàng")) {
             setBusinessErrors([message]);
-            errorMessage = t('managerOrders.form.errors.businessError') + message;
+            errorMessage =
+              t("managerOrders.form.errors.businessError") + message;
           } else if (message.includes("Bạn không có quyền")) {
             setBusinessErrors([message]);
-            errorMessage = t('managerOrders.form.errors.accessError') + message;
+            errorMessage = t("managerOrders.form.errors.accessError") + message;
           } else if (message.includes("Không tìm thấy")) {
             setBusinessErrors([message]);
-            errorMessage = t('managerOrders.form.errors.dataError') + message;
+            errorMessage = t("managerOrders.form.errors.dataError") + message;
           }
         }
 
@@ -641,7 +652,9 @@ export default function OrderForm({
   return (
     <form className="max-w-5xl mx-auto bg-white border rounded-2xl shadow p-8 space-y-6">
       <h2 className="text-2xl font-semibold text-center">
-        {isEdit ? t('managerOrders.edit.title') : t('managerOrders.create.title')}
+        {isEdit
+          ? t("managerOrders.edit.title")
+          : t("managerOrders.create.title")}
       </h2>
 
       {/* Hiển thị lỗi nghiệp vụ */}
@@ -649,66 +662,107 @@ export default function OrderForm({
         <div className="p-4 bg-orange-50 border border-orange-200 rounded-lg">
           <div className="flex items-center justify-between mb-2">
             <h3 className="text-orange-800 font-medium">
-              {t('managerOrders.form.businessRules.title')}
+              {t("managerOrders.form.businessRules.title")}
             </h3>
             <span className="bg-orange-100 text-orange-800 text-xs font-medium px-2 py-1 rounded-full">
-              {businessErrors.length} {t('managerOrders.form.businessRules.rules')}
+              {businessErrors.length}{" "}
+              {t("managerOrders.form.businessRules.rules")}
             </span>
           </div>
 
           {/* Tóm tắt nhanh */}
           <div className="mb-3 p-2 bg-orange-100 rounded text-orange-800 text-sm">
-            <strong> {t('managerOrders.form.businessRules.summary')}:</strong>
+            <strong> {t("managerOrders.form.businessRules.summary")}:</strong>
             {businessErrors.some((err) => err.includes("vượt quá")) &&
-              ` ${t('managerOrders.form.businessRules.adjustOrderInfo')}`}
+              ` ${t("managerOrders.form.businessRules.adjustOrderInfo")}`}
             {businessErrors.some((err) => err.includes("cùng loại")) &&
-              ` ${t('managerOrders.form.businessRules.removeDuplicateProducts')}`}
+              ` ${t(
+                "managerOrders.form.businessRules.removeDuplicateProducts"
+              )}`}
             {businessErrors.some((err) => err.includes("đã tồn tại")) &&
-              ` ${t('managerOrders.form.businessRules.changeOrderInfo')}`}
+              ` ${t("managerOrders.form.businessRules.changeOrderInfo")}`}
             {businessErrors.some((err) => err.includes("không có quyền")) &&
-              ` ${t('managerOrders.form.businessRules.contactAdmin')}`}
+              ` ${t("managerOrders.form.businessRules.contactAdmin")}`}
             {businessErrors.some((err) =>
               err.includes("Lô giao hàng này đã có đơn hàng")
-            ) && ` ${t('managerOrders.form.businessRules.deliveryBatchUsed')}`}
+            ) && ` ${t("managerOrders.form.businessRules.deliveryBatchUsed")}`}
             {businessErrors.some((err) => err.includes("Không tìm thấy")) &&
-              ` ${t('managerOrders.form.businessRules.dataNotFound')}`}
+              ` ${t("managerOrders.form.businessRules.dataNotFound")}`}
           </div>
 
           {/* Hướng dẫn giải quyết */}
           <div className="mt-3 pt-3 border-t border-orange-200">
             <p className="text-orange-600 text-sm font-medium mb-2">
-              💡 {t('managerOrders.form.businessRules.guidance')}:
+              💡 {t("managerOrders.form.businessRules.guidance")}:
             </p>
             <ul className="text-orange-600 text-xs space-y-1">
               {businessErrors.some((err) => err.includes("vượt quá")) && (
-                <li>• {t('managerOrders.form.businessRules.checkOrderInfo')}</li>
+                <li>
+                  • {t("managerOrders.form.businessRules.checkOrderInfo")}
+                </li>
               )}
               {businessErrors.some((err) => err.includes("cùng loại")) && (
-                <li>• {t('managerOrders.form.businessRules.noDuplicateProducts')}</li>
+                <li>
+                  • {t("managerOrders.form.businessRules.noDuplicateProducts")}
+                </li>
               )}
               {businessErrors.some((err) => err.includes("đã tồn tại")) && (
-                <li>• {t('managerOrders.form.businessRules.orderInfoExists')}</li>
+                <li>
+                  • {t("managerOrders.form.businessRules.orderInfoExists")}
+                </li>
               )}
               {businessErrors.some((err) => err.includes("không có quyền")) && (
-                <li>• {t('managerOrders.form.businessRules.contactAdminForPermission')}</li>
+                <li>
+                  •{" "}
+                  {t(
+                    "managerOrders.form.businessRules.contactAdminForPermission"
+                  )}
+                </li>
               )}
               {businessErrors.some((err) =>
                 err.includes("Lô giao hàng này đã có đơn hàng")
-              ) && <li>• {t('managerOrders.form.businessRules.oneOrderPerBatch')}</li>}
+              ) && (
+                <li>
+                  • {t("managerOrders.form.businessRules.oneOrderPerBatch")}
+                </li>
+              )}
               {businessErrors.some((err) =>
                 err.includes("Ngày đặt hàng không được vượt quá")
-              ) && <li>• {t('managerOrders.form.businessRules.orderDateNotExceedCurrent')}</li>}
+              ) && (
+                <li>
+                  •{" "}
+                  {t(
+                    "managerOrders.form.businessRules.orderDateNotExceedCurrent"
+                  )}
+                </li>
+              )}
               {businessErrors.some((err) =>
                 err.includes("Ngày giao thực tế không được")
-              ) && <li>• {t('managerOrders.form.businessRules.deliveryDateNotBeforeOrder')}</li>}
+              ) && (
+                <li>
+                  •{" "}
+                  {t(
+                    "managerOrders.form.businessRules.deliveryDateNotBeforeOrder"
+                  )}
+                </li>
+              )}
               {businessErrors.some((err) =>
                 err.includes("Giảm giá không được vượt quá")
-              ) && <li>• {t('managerOrders.form.businessRules.discountNotExceedTotal')}</li>}
+              ) && (
+                <li>
+                  •{" "}
+                  {t("managerOrders.form.businessRules.discountNotExceedTotal")}
+                </li>
+              )}
               {businessErrors.some((err) =>
                 err.includes("Giảm giá không được âm")
-              ) && <li>• {t('managerOrders.form.businessRules.discountNotNegative')}</li>}
+              ) && (
+                <li>
+                  • {t("managerOrders.form.businessRules.discountNotNegative")}
+                </li>
+              )}
               {businessErrors.some((err) => err.includes("Không tìm thấy")) && (
-                <li>• {t('managerOrders.form.businessRules.dataNotExists')}</li>
+                <li>• {t("managerOrders.form.businessRules.dataNotExists")}</li>
               )}
             </ul>
           </div>
@@ -719,7 +773,10 @@ export default function OrderForm({
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {/* Đợt giao (create = select, edit = read-only) */}
         <div>
-          <label className="block mb-1 text-sm font-medium">{t('managerOrders.form.fields.deliveryBatch')}</label>
+          <label className="block mb-1 text-sm font-medium">
+            {t("managerOrders.form.fields.deliveryBatch")}{" "}
+            <span className="text-red-500">*</span>
+          </label>
 
           {!isEdit ? (
             // CREATE: cho phép chọn
@@ -738,7 +795,9 @@ export default function OrderForm({
                 // effect sau đó sẽ fetch viewDetails và đồng bộ lại mọi thứ
               }}
             >
-              <option value="">-- {t('managerOrders.form.placeholders.selectDeliveryBatch')} --</option>
+              <option value="">
+                -- {t("managerOrders.form.placeholders.selectDeliveryBatch")} --
+              </option>
               {batchOptions.map((b) => (
                 <option key={b.id} value={b.id}>
                   {b.label}
@@ -762,7 +821,10 @@ export default function OrderForm({
 
         {/* Số đợt */}
         <div>
-          <label className="block mb-1 text-sm font-medium">{t('managerOrders.form.fields.deliveryRound')}</label>
+          <label className="block mb-1 text-sm font-medium">
+            {t("managerOrders.form.fields.deliveryRound")}{" "}
+            <span className="text-red-500">*</span>
+          </label>
           <Input
             type="number"
             value={form.deliveryRound ?? ""}
@@ -783,7 +845,8 @@ export default function OrderForm({
         {/* Ngày tạo đơn hàng */}
         <div>
           <label className="block mb-1 text-sm font-medium">
-            {t('managerOrders.form.fields.orderDate')}
+            {t("managerOrders.form.fields.orderDate")}{" "}
+            <span className="text-red-500">*</span>
           </label>
           <DatePicker
             value={form.orderDate}
@@ -793,7 +856,7 @@ export default function OrderForm({
           />
           {isEdit && (
             <p className="text-xs text-gray-500 mt-1">
-              {t('managerOrders.form.fields.orderDateCannotChange')}
+              {t("managerOrders.form.fields.orderDateCannotChange")}
             </p>
           )}
         </div>
@@ -803,7 +866,7 @@ export default function OrderForm({
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div>
           <label className="block mb-1 text-sm font-medium">
-            {t('managerOrders.form.fields.actualDeliveryDate')}
+            {t("managerOrders.form.fields.actualDeliveryDate")}
           </label>
           <DatePicker
             value={form.actualDeliveryDate}
@@ -813,29 +876,50 @@ export default function OrderForm({
         </div>
 
         <div>
-          <label className="block mb-1 text-sm font-medium">{t('managerOrders.form.fields.status')}</label>
-          <select
-            className="w-full p-2 border rounded"
-            value={form.status}
-            onChange={(e) => setField("status", e.target.value as OrderStatus)}
-          >
-            {Object.values(OrderStatus).map((s) => (
-              <option key={s} value={s}>
-                {t(`managerOrders.status.${s.toLowerCase()}`)}
-              </option>
-            ))}
-          </select>
+          <label className="block mb-1 text-sm font-medium">
+            {t("managerOrders.form.fields.status")}{" "}
+            <span className="text-red-500">*</span>
+          </label>
+          {!isEdit ? (
+            // CREATE: cứng "Đang chuẩn bị", không thể thay đổi
+            <Input
+              value={t(`managerOrders.status.${form.status.toLowerCase()}`)}
+              readOnly
+              className="bg-muted/40 cursor-not-allowed"
+            />
+          ) : (
+            // EDIT: có thể chọn trạng thái
+            <select
+              className="w-full p-2 border rounded"
+              value={form.status}
+              onChange={(e) =>
+                setField("status", e.target.value as OrderStatus)
+              }
+            >
+              {Object.values(OrderStatus).map((s) => (
+                <option key={s} value={s}>
+                  {t(`managerOrders.status.${s.toLowerCase()}`)}
+                </option>
+              ))}
+            </select>
+          )}
+          {!isEdit && (
+            <p className="text-xs text-gray-500 mt-1">
+              {t("managerOrders.form.fields.statusCannotChange")}
+            </p>
+          )}
         </div>
 
         {isEdit && (
           <div>
             <label className="block mb-1 text-sm font-medium">
-              {t('managerOrders.form.fields.cancelReason')} {t('managerOrders.form.common.optional')}
+              {t("managerOrders.form.fields.cancelReason")}{" "}
+              {t("managerOrders.form.common.optional")}
             </label>
             <Input
               value={form.cancelReason ?? ""}
               onChange={(e) => setField("cancelReason", e.target.value)}
-              placeholder={t('managerOrders.form.placeholders.cancelReason')}
+              placeholder={t("managerOrders.form.placeholders.cancelReason")}
               disabled={form.status !== OrderStatus.Cancelled}
             />
           </div>
@@ -844,9 +928,11 @@ export default function OrderForm({
 
       {/* Note */}
       <div>
-        <label className="block mb-1 text-sm font-medium">{t('managerOrders.form.fields.note')}</label>
+        <label className="block mb-1 text-sm font-medium">
+          {t("managerOrders.form.fields.note")}
+        </label>
         <Textarea
-          placeholder={t('managerOrders.form.placeholders.note')}
+          placeholder={t("managerOrders.form.placeholders.note")}
           value={form.note ?? ""}
           onChange={(e) => setField("note", e.target.value)}
         />
@@ -855,7 +941,8 @@ export default function OrderForm({
       {/* Order Items */}
       <div className="space-y-2">
         <label className="block mb-1 text-sm font-medium">
-          {t('managerOrders.detail.productList.title')}
+          {t("managerOrders.detail.productList.title")}{" "}
+          <span className="text-red-500">*</span>
         </label>
 
         {/* Hiển thị lỗi tổng quát cho order items */}
@@ -871,12 +958,24 @@ export default function OrderForm({
           <>
             {/* Header giống contract, thêm cột Sản phẩm => 7 cột */}
             <div className="hidden md:grid md:grid-cols-7 gap-2 mb-1 text-xs font-medium text-muted-foreground">
-              <span>{t('managerOrders.form.table.headers.deliveryItem')}</span>
-              <span>{t('managerOrders.form.table.headers.product')}</span>
-              <span>{t('managerOrders.form.table.headers.quantity')}</span>
-              <span>{t('managerOrders.form.table.headers.unitPrice')}</span>
-              <span>{t('managerOrders.form.table.headers.discount')}</span>
-              <span>{t('managerOrders.form.table.headers.note')}</span>
+              <span>
+                {t("managerOrders.form.table.headers.deliveryItem")}{" "}
+                <span className="text-red-500">*</span>
+              </span>
+              <span>
+                {t("managerOrders.form.table.headers.product")}{" "}
+                <span className="text-red-500">*</span>
+              </span>
+              <span>
+                {t("managerOrders.form.table.headers.quantity")}{" "}
+                <span className="text-red-500">*</span>
+              </span>
+              <span>
+                {t("managerOrders.form.table.headers.unitPrice")}{" "}
+                <span className="text-red-500">*</span>
+              </span>
+              <span>{t("managerOrders.form.table.headers.discount")}</span>
+              <span>{t("managerOrders.form.table.headers.note")}</span>
               <span></span>
             </div>
 
@@ -899,7 +998,10 @@ export default function OrderForm({
                   }`}
                   disabled={loadingOptions}
                 >
-                  <option value="">-- {t('managerOrders.form.placeholders.selectDeliveryItem')} --</option>
+                  <option value="">
+                    -- {t("managerOrders.form.placeholders.selectDeliveryItem")}{" "}
+                    --
+                  </option>
                   {(deliveryItemOptions ?? []).map((it) => (
                     <option
                       key={it.contractDeliveryItemId}
@@ -924,7 +1026,9 @@ export default function OrderForm({
                   }`}
                   disabled={loadingOptions}
                 >
-                  <option value="">-- {t('managerOrders.form.placeholders.selectProduct')} --</option>
+                  <option value="">
+                    -- {t("managerOrders.form.placeholders.selectProduct")} --
+                  </option>
                   {(productOptions ?? []).map((p) => (
                     <option key={p.productId} value={p.productId}>
                       {p.name}
@@ -1014,7 +1118,7 @@ export default function OrderForm({
 
                 {/* Ghi chú */}
                 <Input
-                  placeholder={t('managerOrders.form.placeholders.note')}
+                  placeholder={t("managerOrders.form.placeholders.note")}
                   value={row.note ?? ""}
                   onChange={(e) => updateRow(idx, "note", e.target.value)}
                 />
@@ -1024,7 +1128,7 @@ export default function OrderForm({
                   variant="destructive"
                   onClick={() => removeRow(idx)}
                 >
-                  {t('managerOrders.form.actions.removeItem')}
+                  {t("managerOrders.form.actions.removeItem")}
                 </Button>
               </div>
             ))}
@@ -1037,26 +1141,30 @@ export default function OrderForm({
           onClick={addRow}
           disabled={loadingOptions || !form.deliveryBatchId}
         >
-          {t('managerOrders.form.actions.addItem')}
+          {t("managerOrders.form.actions.addItem")}
         </Button>
 
         {/* Tổng */}
         <div className="flex items-center justify-between mt-2 text-sm text-gray-600">
           <div>
-            {t('managerOrders.form.summary.totalQuantity')}: <strong>{totalQuantity.toLocaleString()} kg</strong>
+            {t("managerOrders.form.summary.totalQuantity")}:{" "}
+            <strong>{totalQuantity.toLocaleString()} kg</strong>
           </div>
           <div>
-            {t('managerOrders.form.summary.totalAmount')}: <strong>{fmtVnd(totalAmount)} VNĐ</strong>
+            {t("managerOrders.form.summary.totalAmount")}:{" "}
+            <strong>{fmtVnd(totalAmount)} VNĐ</strong>
           </div>
         </div>
       </div>
 
       <DialogFooter className="flex justify-between pt-4">
         <Button type="submit" onClick={handleSubmit} disabled={saving}>
-          {isEdit ? t('managerOrders.form.actions.updateOrder') : t('managerOrders.form.actions.createOrder')}
+          {isEdit
+            ? t("managerOrders.form.actions.updateOrder")
+            : t("managerOrders.form.actions.createOrder")}
         </Button>
         <Button type="button" variant="outline" onClick={() => router.back()}>
-          {t('managerOrders.detail.actions.back')}
+          {t("managerOrders.detail.actions.back")}
         </Button>
       </DialogFooter>
     </form>

--- a/DakLakCoffeeSupplyChain/src/components/orders/OrderItemFormDialog.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/orders/OrderItemFormDialog.tsx
@@ -24,7 +24,6 @@ import { toast } from "sonner";
 import axios from "axios";
 import { useTranslation } from "react-i18next";
 
-
 interface ContractDeliveryItemOption {
   contractDeliveryItemId: string;
   label: string;
@@ -59,7 +58,7 @@ export default function OrderItemFormDialog({
   onSuccess,
 }: OrderItemFormDialogProps) {
   const { t } = useTranslation();
-  
+
   const [formData, setFormData] = useState<
     OrderItemCreateForOrder | OrderItemUpdateDto
   >({
@@ -151,7 +150,9 @@ export default function OrderItemFormDialog({
     if (id && !map.has(id)) {
       map.set(id, {
         contractDeliveryItemId: id,
-        label: t("managerOrders.detail.addOrderItem.labels.currentDeliveryItem"),
+        label: t(
+          "managerOrders.detail.addOrderItem.labels.currentDeliveryItem"
+        ),
       });
     }
     return Array.from(map.values());
@@ -160,22 +161,32 @@ export default function OrderItemFormDialog({
   const handleSubmit = async () => {
     // Kiểm tra client-side
     if (!formData.contractDeliveryItemId) {
-      toast.error(t("managerOrders.detail.addOrderItem.validation.selectContractDeliveryItem"));
+      toast.error(
+        t(
+          "managerOrders.detail.addOrderItem.validation.selectContractDeliveryItem"
+        )
+      );
       return;
     }
 
     if (!formData.productId) {
-      toast.error(t("managerOrders.detail.addOrderItem.validation.selectProduct"));
+      toast.error(
+        t("managerOrders.detail.addOrderItem.validation.selectProduct")
+      );
       return;
     }
 
     if ((formData.quantity ?? 0) <= 0) {
-      toast.error(t("managerOrders.detail.addOrderItem.validation.quantityRequired"));
+      toast.error(
+        t("managerOrders.detail.addOrderItem.validation.quantityRequired")
+      );
       return;
     }
 
     if ((formData.unitPrice ?? 0) < 0) {
-      toast.error(t("managerOrders.detail.addOrderItem.validation.unitPriceInvalid"));
+      toast.error(
+        t("managerOrders.detail.addOrderItem.validation.unitPriceInvalid")
+      );
       return;
     }
 
@@ -183,7 +194,9 @@ export default function OrderItemFormDialog({
       (formData.discountAmount ?? 0) < 0 ||
       (formData.discountAmount ?? 0) > 100
     ) {
-      toast.error(t("managerOrders.detail.addOrderItem.validation.discountRange"));
+      toast.error(
+        t("managerOrders.detail.addOrderItem.validation.discountRange")
+      );
       return;
     }
 
@@ -191,21 +204,29 @@ export default function OrderItemFormDialog({
     try {
       if (mode === "create") {
         await createOrderItem(formData as OrderItemCreateForOrder);
-        toast.success(t("managerOrders.detail.addOrderItem.messages.addSuccess"));
+        toast.success(
+          t("managerOrders.detail.addOrderItem.messages.addSuccess")
+        );
       } else {
         await updateOrderItem(formData as OrderItemUpdateDto);
-        toast.success(t("managerOrders.detail.addOrderItem.messages.updateSuccess"));
+        toast.success(
+          t("managerOrders.detail.addOrderItem.messages.updateSuccess")
+        );
       }
 
       onSuccess?.();
       onOpenChange(false);
     } catch (error: any) {
-      let message = t("managerOrders.detail.addOrderItem.messages.unknownError");
+      let message = t(
+        "managerOrders.detail.addOrderItem.messages.unknownError"
+      );
 
       if (axios.isAxiosError(error)) {
         message =
           error.response?.data?.message ??
-          t("managerOrders.detail.addOrderItem.messages.serverError", { status: error.response?.status });
+          t("managerOrders.detail.addOrderItem.messages.serverError", {
+            status: error.response?.status,
+          });
       } else if (error instanceof Error) {
         message = error.message;
       }
@@ -230,13 +251,20 @@ export default function OrderItemFormDialog({
         <div className="grid gap-2 px-5 py-4">
           {/* OrderCode: có thể ẩn hoặc hiển thị read-only để người dùng biết họ đang ở đơn hàng nào */}
           <div className="grid gap-1">
-            <Label htmlFor="orderCode">{t("managerOrders.detail.addOrderItem.fields.orderCode")}</Label>
+            <Label htmlFor="orderCode">
+              {t("managerOrders.detail.addOrderItem.fields.orderCode")}
+            </Label>
             <Input id="orderCode" value={orderCode ?? ""} disabled />
           </div>
 
           {/* Mặt hàng đợt giao */}
           <div className="grid gap-1">
-            <Label htmlFor="contractDeliveryItemId">{t("managerOrders.detail.addOrderItem.fields.contractDeliveryItem")}</Label>
+            <Label htmlFor="contractDeliveryItemId">
+              {t(
+                "managerOrders.detail.addOrderItem.fields.contractDeliveryItem"
+              )}{" "}
+              <span className="text-red-500">*</span>
+            </Label>
             <Select
               value={(formData.contractDeliveryItemId as string) || undefined}
               onValueChange={(value) => {
@@ -247,7 +275,11 @@ export default function OrderItemFormDialog({
               }}
             >
               <SelectTrigger id="contractDeliveryItemId" className="w-full">
-                <SelectValue placeholder={t("managerOrders.detail.addOrderItem.placeholders.selectContractDeliveryItem")} />
+                <SelectValue
+                  placeholder={t(
+                    "managerOrders.detail.addOrderItem.placeholders.selectContractDeliveryItem"
+                  )}
+                />
               </SelectTrigger>
               <SelectContent>
                 {mergedCdiOptions.map((it) => (
@@ -264,7 +296,10 @@ export default function OrderItemFormDialog({
 
           {/* Sản phẩm */}
           <div className="grid gap-1">
-            <Label htmlFor="productId">{t("managerOrders.detail.addOrderItem.fields.product")}</Label>
+            <Label htmlFor="productId">
+              {t("managerOrders.detail.addOrderItem.fields.product")}{" "}
+              <span className="text-red-500">*</span>
+            </Label>
             <Select
               value={formData.productId || undefined}
               onValueChange={(value) =>
@@ -272,7 +307,11 @@ export default function OrderItemFormDialog({
               }
             >
               <SelectTrigger id="productId" className="w-full">
-                <SelectValue placeholder={t("managerOrders.detail.addOrderItem.placeholders.selectProduct")} />
+                <SelectValue
+                  placeholder={t(
+                    "managerOrders.detail.addOrderItem.placeholders.selectProduct"
+                  )}
+                />
               </SelectTrigger>
               <SelectContent>
                 {productOptions.map((p) => (
@@ -289,7 +328,10 @@ export default function OrderItemFormDialog({
 
           {/* Số lượng (kg) */}
           <div className="grid gap-1">
-            <Label htmlFor="quantity">{t("managerOrders.detail.addOrderItem.fields.quantity")}</Label>
+            <Label htmlFor="quantity">
+              {t("managerOrders.detail.addOrderItem.fields.quantity")}{" "}
+              <span className="text-red-500">*</span>
+            </Label>
             <div className="relative">
               <Input
                 id="quantity"
@@ -299,7 +341,9 @@ export default function OrderItemFormDialog({
                 onChange={handleChange}
                 min={0}
                 step={1}
-                placeholder={t("managerOrders.detail.addOrderItem.placeholders.quantity")}
+                placeholder={t(
+                  "managerOrders.detail.addOrderItem.placeholders.quantity"
+                )}
                 className="pr-14"
               />
               <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-500">
@@ -310,7 +354,10 @@ export default function OrderItemFormDialog({
 
           {/* Đơn giá (VNĐ/kg) */}
           <div className="grid gap-1">
-            <Label htmlFor="unitPrice">{t("managerOrders.detail.addOrderItem.fields.unitPrice")}</Label>
+            <Label htmlFor="unitPrice">
+              {t("managerOrders.detail.addOrderItem.fields.unitPrice")}{" "}
+              <span className="text-red-500">*</span>
+            </Label>
             <div className="relative">
               <Input
                 id="unitPrice"
@@ -320,7 +367,9 @@ export default function OrderItemFormDialog({
                 onChange={handleChange}
                 min={0}
                 step={100} // hoặc 1000 tuỳ quy định
-                placeholder={t("managerOrders.detail.addOrderItem.placeholders.unitPrice")}
+                placeholder={t(
+                  "managerOrders.detail.addOrderItem.placeholders.unitPrice"
+                )}
                 className="pr-24"
               />
               <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-500">
@@ -331,7 +380,9 @@ export default function OrderItemFormDialog({
 
           {/* Chiết khấu (%) */}
           <div className="grid gap-1">
-            <Label htmlFor="discountAmount">{t("managerOrders.detail.addOrderItem.fields.discountAmount")}</Label>
+            <Label htmlFor="discountAmount">
+              {t("managerOrders.detail.addOrderItem.fields.discountAmount")}
+            </Label>
             <div className="relative">
               <Input
                 id="discountAmount"
@@ -342,7 +393,9 @@ export default function OrderItemFormDialog({
                 min={0}
                 max={100}
                 step={1}
-                placeholder={t("managerOrders.detail.addOrderItem.placeholders.discountAmount")}
+                placeholder={t(
+                  "managerOrders.detail.addOrderItem.placeholders.discountAmount"
+                )}
                 className="pr-10"
               />
               <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-500">
@@ -352,13 +405,17 @@ export default function OrderItemFormDialog({
           </div>
 
           <div className="grid gap-1">
-            <Label htmlFor="note">{t("managerOrders.detail.addOrderItem.fields.note")}</Label>
+            <Label htmlFor="note">
+              {t("managerOrders.detail.addOrderItem.fields.note")}
+            </Label>
             <Textarea
               id="note"
               name="note"
               value={formData.note ?? ""}
               onChange={handleChange}
-              placeholder={t("managerOrders.detail.addOrderItem.placeholders.note")}
+              placeholder={t(
+                "managerOrders.detail.addOrderItem.placeholders.note"
+              )}
             />
           </div>
         </div>
@@ -376,7 +433,11 @@ export default function OrderItemFormDialog({
             onClick={handleSubmit}
             disabled={loading}
           >
-            {loading ? t("managerOrders.detail.addOrderItem.actions.saving") : mode === "create" ? t("managerOrders.detail.addOrderItem.actions.add") : t("managerOrders.detail.addOrderItem.actions.update")}
+            {loading
+              ? t("managerOrders.detail.addOrderItem.actions.saving")
+              : mode === "create"
+              ? t("managerOrders.detail.addOrderItem.actions.add")
+              : t("managerOrders.detail.addOrderItem.actions.update")}
           </Button>
         </div>
       </FormDialog.Content>

--- a/DakLakCoffeeSupplyChain/src/i18n/locales/en.json
+++ b/DakLakCoffeeSupplyChain/src/i18n/locales/en.json
@@ -5322,7 +5322,6 @@
           "dataNotExists": "Data does not exist or has been deleted"
         },
         "fields": {
-          "orderDateCannotChange": "Order creation date cannot be changed"
         },
         "table": {
           "headers": {
@@ -5471,7 +5470,8 @@
         "note": "Note",
         "status": "Status",
         "cancelReason": "Cancel reason",
-        "orderDateCannotChange": "Order creation date cannot be changed"
+        "orderDateCannotChange": "Order creation date cannot be changed",
+        "statusCannotChange": "Status cannot be changed"
       },
       "common": {
         "optional": "(optional)"

--- a/DakLakCoffeeSupplyChain/src/i18n/locales/vi.json
+++ b/DakLakCoffeeSupplyChain/src/i18n/locales/vi.json
@@ -5364,7 +5364,7 @@
           "dataNotExists": "Dữ liệu không tồn tại hoặc đã bị xóa"
         },
         "fields": {
-          "orderDateCannotChange": "Ngày tạo đơn hàng không thể thay đổi"
+          
         },
         "table": {
           "headers": {
@@ -5513,7 +5513,8 @@
         "note": "Ghi chú",
         "status": "Trạng thái",
         "cancelReason": "Lý do hủy",
-        "orderDateCannotChange": "Ngày tạo đơn hàng không thể thay đổi"
+        "orderDateCannotChange": "Ngày tạo đơn hàng không thể thay đổi",
+        "statusCannotChange": "Trạng thái không thể thay đổi"
       },
       "common": {
         "optional": "(tùy chọn)"


### PR DESCRIPTION
## ☕ Feature: Manager – Order form required fields & default status

### 📌 Objective
Enhance the **Order creation flow** for the Manager role by:  
- Highlighting required fields with a red asterisk (`*`) for better UX  
- Setting the default status of a newly created order to **"Đang xử lý"** (Processing)  

---

### ✅ Key Changes
- Updated `OrderForm.tsx` to add red `*` for required fields  
- Updated `OrderItemFormDialog.tsx` to add red `*` for required fields  
- Set default status = "Đang xử lý" when creating new orders  
- Updated i18n files (`en.json`, `vi.json`) for label consistency  

---

### 📁 Affected Files
- `src/app/dashboard/manager/business-buyers/[id]/page.tsx`  
- `src/components/orders/OrderForm.tsx`  
- `src/components/orders/OrderItemFormDialog.tsx`  
- `src/i18n/locales/en.json`  
- `src/i18n/locales/vi.json`  

---

### 🧪 How to Test
1. Navigate to: `/dashboard/manager/orders/create`  
2. Verify:  
   - Required fields show red `*` indicators  
   - When submitting without filling required fields → validation error appears  
   - When creating a new order → `status` is automatically set to **"Đang xử lý"**  
3. Edit an existing order → ensure status logic is unchanged  

---

### 🧪 Test Cases
- [x] ✅ Required fields show red `*` indicators  
- [x] ✅ Validation error triggers when leaving required fields empty  
- [x] ✅ New order created with default status = "Đang xử lý"  
- [x] ❌ Invalid input still prevents form submission  

---

### 🔍 Notes
- UI change only for form indicators, no layout changes  
- Default status logic applied only in **create order** scenario  
- Localized labels updated in EN & VI translations  

---

### 🔗 Related
- Module: `Order`  
- Role: `Manager`  

---

### ☑️ Checklist (before PR)
- [ ] Verified UI shows required field indicators correctly  
- [ ] Verified default order status is set as expected  
- [ ] Checked no console warnings or errors  
- [ ] Commit message & description follow conventions  
