### PR TITLE
feat(order-ui): lock UnitPrice/Discount (derived from batch item); layout tweaks — create: Batch & Round 1/2 each, edit: Batch/Round/ActualDeliveryDate 1/3 each; show CancelReason only when status=Canceled; Orders list shows CreatedAt only, default filter now→past & sort newest first; i18n updates

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/orders/[id]/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/orders/[id]/page.tsx
@@ -52,27 +52,27 @@ export default function OrderDetailPage() {
     { label: string; className: string }
   > = {
     Pending: {
-      label: t('managerOrders.status.pending'),
+      label: t("managerOrders.status.pending"),
       className: "bg-purple-100 text-purple-700",
     },
     Preparing: {
-      label: t('managerOrders.status.preparing'),
+      label: t("managerOrders.status.preparing"),
       className: "bg-blue-100 text-blue-700",
     },
     Shipped: {
-      label: t('managerOrders.status.shipped'),
+      label: t("managerOrders.status.shipped"),
       className: "bg-amber-100 text-amber-700",
     },
     Delivered: {
-      label: t('managerOrders.status.delivered'),
+      label: t("managerOrders.status.delivered"),
       className: "bg-green-100 text-green-700",
     },
     Cancelled: {
-      label: t('managerOrders.status.cancelled'),
+      label: t("managerOrders.status.cancelled"),
       className: "bg-red-100 text-red-700",
     },
     Failed: {
-      label: t('managerOrders.status.failed'),
+      label: t("managerOrders.status.failed"),
       className: "bg-gray-200 text-gray-600",
     },
   } as const;
@@ -95,8 +95,8 @@ export default function OrderDetailPage() {
       const data = await getOrderDetails(id);
       setOrder(data);
     } catch (e) {
-      console.error(t('managerOrders.detail.error.loadData'), e);
-      toast.error(t('managerOrders.detail.error.loadData'));
+      console.error(t("managerOrders.detail.error.loadData"), e);
+      toast.error(t("managerOrders.detail.error.loadData"));
     } finally {
       setLoading(false);
     }
@@ -147,7 +147,7 @@ export default function OrderDetailPage() {
     if (!order) return;
     getProductOptions()
       .then(setProducts)
-      .catch(() => toast.error(t('managerOrders.detail.error.loadData')));
+      .catch(() => toast.error(t("managerOrders.detail.error.loadData")));
   }, [order]);
 
   // Nạp dropdown ContractDeliveryItems từ chi tiết đợt giao
@@ -171,7 +171,7 @@ export default function OrderDetailPage() {
           }))
         );
       } catch {
-        toast.error(t('managerOrders.detail.error.loadData'));
+        toast.error(t("managerOrders.detail.error.loadData"));
       }
     })();
   }, [order]);
@@ -212,7 +212,7 @@ export default function OrderDetailPage() {
           }))
         );
       } catch {
-        toast.error(t('managerOrders.detail.error.loadData'));
+        toast.error(t("managerOrders.detail.error.loadData"));
         setContractDeliveryItems([]);
       }
     })();
@@ -269,8 +269,10 @@ export default function OrderDetailPage() {
           : prev
       );
 
-      toast.success(t('managerOrders.detail.actions.deleteSuccess'), {
-        description: `${t('managerOrders.detail.actions.deleteMessage', { productName: itemToDelete.productName })}`,
+      toast.success(t("managerOrders.detail.actions.deleteSuccess"), {
+        description: `${t("managerOrders.detail.actions.deleteMessage", {
+          productName: itemToDelete.productName,
+        })}`,
       });
 
       setShowDeleteDialog(false);
@@ -282,7 +284,9 @@ export default function OrderDetailPage() {
       );
     } catch (e: any) {
       const msg =
-        e?.response?.data?.message || e?.message || t('managerOrders.detail.actions.deleteError');
+        e?.response?.data?.message ||
+        e?.message ||
+        t("managerOrders.detail.actions.deleteError");
       toast.error("Lỗi", { description: msg });
     } finally {
       setDeleting(false);
@@ -292,7 +296,9 @@ export default function OrderDetailPage() {
   if (loading) {
     return (
       <div className="p-6">
-        <div className="animate-pulse text-gray-500">{t('managerOrders.detail.loading')}</div>
+        <div className="animate-pulse text-gray-500">
+          {t("managerOrders.detail.loading")}
+        </div>
       </div>
     );
   }
@@ -301,10 +307,10 @@ export default function OrderDetailPage() {
     return (
       <div className="p-6">
         <div className="rounded-xl border bg-white p-8 text-center text-gray-600">
-          {t('managerOrders.detail.error.notFound')}
+          {t("managerOrders.detail.error.notFound")}
           <div className="mt-4">
             <Button variant="outline" onClick={() => router.back()}>
-              {t('managerOrders.detail.actions.back')}
+              {t("managerOrders.detail.actions.back")}
             </Button>
           </div>
         </div>
@@ -317,17 +323,19 @@ export default function OrderDetailPage() {
       <div className="w-full max-w-6xl space-y-6">
         {/* Title / Header */}
         <div className="flex items-center justify-between">
-                     <div className="flex items-center gap-3 text-2xl font-semibold text-gray-800">
-             <div className="flex flex-col">
-               <span>{t('managerOrders.detail.title')}: {order.orderCode}</span>
-               {order.deliveryBatchCode && (
-                 <span className="text-sm font-normal text-gray-600">
-                   {t('managerOrders.detail.orderInfo.fields.deliveryRound')}{" "}
-                   <span className="font-medium">{order.deliveryBatchCode}</span>
-                 </span>
-               )}
-             </div>
-           </div>
+          <div className="flex items-center gap-3 text-2xl font-semibold text-gray-800">
+            <div className="flex flex-col">
+              <span>
+                {t("managerOrders.detail.title")}: {order.orderCode}
+              </span>
+              {order.deliveryBatchCode && (
+                <span className="text-sm font-normal text-gray-600">
+                  {t("managerOrders.detail.orderInfo.fields.deliveryRound")}{" "}
+                  <span className="font-medium">{order.deliveryBatchCode}</span>
+                </span>
+              )}
+            </div>
+          </div>
 
           <Button
             className="bg-[#f59e0b] hover:bg-[#d97706] text-white font-medium px-4 py-2 rounded-lg shadow-md"
@@ -335,7 +343,7 @@ export default function OrderDetailPage() {
               router.push(`/dashboard/manager/orders/${order.orderId}/edit`)
             }
           >
-            {t('managerOrders.detail.actions.edit')}
+            {t("managerOrders.detail.actions.edit")}
           </Button>
         </div>
 
@@ -344,25 +352,53 @@ export default function OrderDetailPage() {
         {/* Order Info */}
         <Card>
           <CardHeader>
-            <CardTitle>{t('managerOrders.detail.orderInfo.title')}</CardTitle>
+            <CardTitle>{t("managerOrders.detail.orderInfo.title")}</CardTitle>
           </CardHeader>
 
           <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
             <div>
-              <strong>{t('managerOrders.detail.orderInfo.fields.orderCode')}</strong> {order.orderCode}
+              <strong>
+                {t("managerOrders.detail.orderInfo.fields.orderCode")}
+              </strong>{" "}
+              {order.orderCode}
             </div>
             <div>
-              <strong>{t('managerOrders.detail.orderInfo.fields.contractNumber')}</strong> {order.contractNumber}
+              <strong>
+                {t("managerOrders.detail.orderInfo.fields.contractNumber")}
+              </strong>{" "}
+              {order.contractNumber}
             </div>
 
             <div>
-              <strong>{t('managerOrders.detail.orderInfo.fields.deliveryRound')}</strong>{" "}
+              <strong>
+                {t("managerOrders.detail.orderInfo.fields.deliveryRound")}
+              </strong>{" "}
               {order.deliveryRound != null ? String(order.deliveryRound) : "—"}
             </div>
 
             <div className="flex items-center gap-1">
-              <strong>{t('managerOrders.detail.orderInfo.fields.deliveryDate')}</strong>
-              <Tooltip content={t('managerOrders.detail.orderInfo.tooltips.deliveryDate')}>
+              <strong>
+                {t("managerOrders.detail.orderInfo.fields.orderDate")}
+              </strong>
+              <Tooltip
+                content={t("managerOrders.detail.orderInfo.tooltips.orderDate")}
+              >
+                <Info className="w-3 h-3 text-gray-400" />
+              </Tooltip>
+              <span className="ml-1">
+                {order.orderDate ? formatDate(order.orderDate) : "—"}
+              </span>
+            </div>
+
+            <div className="flex items-center gap-1">
+              <strong>
+                {t("managerOrders.detail.orderInfo.fields.deliveryDate")}
+              </strong>
+              <Tooltip
+                content={t(
+                  "managerOrders.detail.orderInfo.tooltips.deliveryDate"
+                )}
+              >
                 <Info className="w-3 h-3 text-gray-400" />
               </Tooltip>
               <span className="ml-1">
@@ -375,8 +411,14 @@ export default function OrderDetailPage() {
             </div>
 
             <div className="flex items-center gap-1">
-              <strong>{t('managerOrders.detail.orderInfo.fields.totalAmount')}</strong>
-              <Tooltip content={t('managerOrders.detail.orderInfo.tooltips.totalAmount')}>
+              <strong>
+                {t("managerOrders.detail.orderInfo.fields.totalAmount")}
+              </strong>
+              <Tooltip
+                content={t(
+                  "managerOrders.detail.orderInfo.tooltips.totalAmount"
+                )}
+              >
                 <Info className="w-3 h-3 text-gray-400" />
               </Tooltip>
               <span className="ml-1">
@@ -387,7 +429,9 @@ export default function OrderDetailPage() {
             </div>
 
             <div>
-              <strong>{t('managerOrders.detail.orderInfo.fields.status')}</strong>
+              <strong>
+                {t("managerOrders.detail.orderInfo.fields.status")}
+              </strong>
               <span
                 className={`ml-2 px-2 py-1 rounded text-xs font-semibold ${
                   orderStatusBadgeMap[order.status]?.className
@@ -398,12 +442,16 @@ export default function OrderDetailPage() {
             </div>
 
             <div className="md:col-span-2">
-              <strong>{t('managerOrders.detail.orderInfo.fields.note')}</strong> {order.note?.trim() ? order.note : "—"}
+              <strong>{t("managerOrders.detail.orderInfo.fields.note")}</strong>{" "}
+              {order.note?.trim() ? order.note : "—"}
             </div>
 
             {order.cancelReason?.trim() && (
               <div className="md:col-span-2">
-                <strong>{t('managerOrders.detail.orderInfo.fields.cancelReason')}</strong> {order.cancelReason}
+                <strong>
+                  {t("managerOrders.detail.orderInfo.fields.cancelReason")}
+                </strong>{" "}
+                {order.cancelReason}
               </div>
             )}
           </CardContent>
@@ -412,12 +460,14 @@ export default function OrderDetailPage() {
         {/* Danh sách mặt hàng */}
         <div className="rounded-xl border bg-white p-4">
           <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-base font-semibold">{t('managerOrders.detail.productList.title')}</h2>
+            <h2 className="text-base font-semibold">
+              {t("managerOrders.detail.productList.title")}
+            </h2>
             <Button
               className="bg-black text-white hover:bg-gray-800"
               onClick={openCreateDialog}
             >
-              {t('managerOrders.detail.productList.addItem')}
+              {t("managerOrders.detail.productList.addItem")}
             </Button>
           </div>
 
@@ -426,29 +476,33 @@ export default function OrderDetailPage() {
               <thead className="bg-gray-100 text-gray-700">
                 <tr>
                   <th className="px-4 py-2 text-left whitespace-nowrap">
-                    {t('managerOrders.detail.productList.headers.productName')}
+                    {t("managerOrders.detail.productList.headers.productName")}
                   </th>
                   <th className="px-4 py-2 text-center whitespace-nowrap">
-                    {t('managerOrders.detail.productList.headers.quantity')}
+                    {t("managerOrders.detail.productList.headers.quantity")}
                   </th>
                   <th className="px-4 py-2 text-center whitespace-nowrap">
-                    {t('managerOrders.detail.productList.headers.unitPrice')}
+                    {t("managerOrders.detail.productList.headers.unitPrice")}
                   </th>
                   <th className="px-4 py-2 text-center whitespace-nowrap">
-                    {t('managerOrders.detail.productList.headers.discount')}
+                    {t("managerOrders.detail.productList.headers.discount")}
                   </th>
                   <th className="px-4 py-2 text-center whitespace-nowrap">
-                    {t('managerOrders.detail.productList.headers.totalPrice')}
+                    {t("managerOrders.detail.productList.headers.totalPrice")}
                   </th>
-                  <th className="px-4 py-2 text-left">{t('managerOrders.detail.productList.headers.note')}</th>
-                  <th className="px-4 py-2 text-center">{t('managerOrders.detail.productList.headers.actions')}</th>
+                  <th className="px-4 py-2 text-left">
+                    {t("managerOrders.detail.productList.headers.note")}
+                  </th>
+                  <th className="px-4 py-2 text-center">
+                    {t("managerOrders.detail.productList.headers.actions")}
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 {items.length === 0 ? (
                   <tr>
                     <td className="py-8 text-center text-gray-500" colSpan={7}>
-                      {t('managerOrders.detail.productList.empty')}
+                      {t("managerOrders.detail.productList.empty")}
                     </td>
                   </tr>
                 ) : (
@@ -481,7 +535,9 @@ export default function OrderDetailPage() {
                       <td className="px-4 py-2">{it.note || "—"}</td>
                       <td className="px-4 py-2 whitespace-nowrap">
                         <div className="flex justify-center gap-[2px]">
-                          <Tooltip content={t('managerOrders.detail.actions.edit')}>
+                          <Tooltip
+                            content={t("managerOrders.detail.actions.edit")}
+                          >
                             <Button
                               variant="ghost"
                               className="h-7 w-7 p-[2px]"
@@ -490,7 +546,9 @@ export default function OrderDetailPage() {
                               <Pencil className="w-4 h-4 text-[#f59e0b]" />
                             </Button>
                           </Tooltip>
-                          <Tooltip content={t('managerOrders.detail.actions.delete')}>
+                          <Tooltip
+                            content={t("managerOrders.detail.actions.delete")}
+                          >
                             <Button
                               variant="ghost"
                               className="h-7 w-7 p-[2px]"
@@ -515,15 +573,16 @@ export default function OrderDetailPage() {
           {totalPages > 1 && (
             <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center mt-4 px-4 py-2 bg-gray-50 border rounded-md text-sm text-gray-700">
               <div className="text-sm text-gray-600">
-                {t('managerOrders.detail.pagination.showing')}{" "}
+                {t("managerOrders.detail.pagination.showing")}{" "}
                 <span className="font-medium">
                   {(currentPage - 1) * ITEMS_PER_PAGE + 1}
                 </span>
-                {t('managerOrders.detail.pagination.to')}
+                {t("managerOrders.detail.pagination.to")}
                 <span className="font-medium">
                   {Math.min(currentPage * ITEMS_PER_PAGE, totalItems)}
                 </span>{" "}
-                {t('managerOrders.detail.pagination.of')} {totalItems} {t('managerOrders.detail.pagination.items')}
+                {t("managerOrders.detail.pagination.of")} {totalItems}{" "}
+                {t("managerOrders.detail.pagination.items")}
               </div>
               <div className="flex gap-2 justify-end mt-2 sm:mt-0">
                 <Button
@@ -535,12 +594,12 @@ export default function OrderDetailPage() {
                     setCurrentPage((prev) => Math.max(prev - 1, 1))
                   }
                 >
-                  {t('managerOrders.detail.pagination.previous')}
+                  {t("managerOrders.detail.pagination.previous")}
                 </Button>
                 <span className="flex items-center px-2">
-                  {t('managerOrders.detail.pagination.page')}{" "}
-                  <span className="mx-1 font-semibold">{currentPage}</span> {t('managerOrders.detail.pagination.of')}{" "}
-                  {totalPages}
+                  {t("managerOrders.detail.pagination.page")}{" "}
+                  <span className="mx-1 font-semibold">{currentPage}</span>{" "}
+                  {t("managerOrders.detail.pagination.of")} {totalPages}
                 </span>
                 <Button
                   variant="outline"
@@ -551,7 +610,7 @@ export default function OrderDetailPage() {
                     setCurrentPage((prev) => Math.min(prev + 1, totalPages))
                   }
                 >
-                  {t('managerOrders.detail.pagination.next')}
+                  {t("managerOrders.detail.pagination.next")}
                 </Button>
               </div>
             </div>
@@ -564,7 +623,7 @@ export default function OrderDetailPage() {
             variant="outline"
             onClick={() => router.push("/dashboard/manager/orders")}
           >
-            {t('managerOrders.detail.actions.back')}
+            {t("managerOrders.detail.actions.back")}
           </Button>
         </div>
 
@@ -584,17 +643,21 @@ export default function OrderDetailPage() {
         <ConfirmDialog
           open={showDeleteDialog}
           onOpenChange={setShowDeleteDialog}
-          title={t('managerOrders.detail.actions.deleteConfirm')}
+          title={t("managerOrders.detail.actions.deleteConfirm")}
           description={
             <span
               dangerouslySetInnerHTML={{
-                __html: t('managerOrders.detail.actions.deleteMessage', {
-                  productName: itemToDelete?.productName || '—',
+                __html: t("managerOrders.detail.actions.deleteMessage", {
+                  productName: itemToDelete?.productName || "—",
                 }),
               }}
             />
           }
-          confirmText={deleting ? t('managerOrders.detail.actions.loading') : t('managerOrders.detail.actions.delete')}
+          confirmText={
+            deleting
+              ? t("managerOrders.detail.actions.loading")
+              : t("managerOrders.detail.actions.delete")
+          }
           cancelText="Huỷ"
           onConfirm={handleDeleteItem}
           loading={deleting}

--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/orders/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/orders/page.tsx
@@ -79,12 +79,8 @@ export default function OrdersPage() {
     const matchesStatus =
       selectedStatus === "ALL" || o.status === selectedStatus;
 
-    // Ưu tiên ngày giao thực tế (ActualDeliveryDate) nếu có, không thì OrderDate
-    const orderDate = o.actualDeliveryDate
-      ? new Date(o.actualDeliveryDate)
-      : o.orderDate
-      ? new Date(o.orderDate)
-      : null;
+    // Sử dụng ngày tạo đơn hàng (OrderDate)
+    const orderDate = o.orderDate ? new Date(o.orderDate) : null;
 
     const matchesDate =
       (!fromDate || (orderDate && orderDate >= fromDate)) &&
@@ -93,8 +89,15 @@ export default function OrdersPage() {
     return matchesSearch && matchesStatus && matchesDate;
   });
 
-  const totalPages = Math.ceil(filtered.length / ITEMS_PER_PAGE) || 1;
-  const paginated = filtered.slice(
+  // Sắp xếp theo ngày tạo đơn hàng mới nhất trước
+  const sorted = filtered.sort((a, b) => {
+    const dateA = a.orderDate ? new Date(a.orderDate).getTime() : 0;
+    const dateB = b.orderDate ? new Date(b.orderDate).getTime() : 0;
+    return dateB - dateA; // Mới nhất trước
+  });
+
+  const totalPages = Math.ceil(sorted.length / ITEMS_PER_PAGE) || 1;
+  const paginated = sorted.slice(
     (currentPage - 1) * ITEMS_PER_PAGE,
     currentPage * ITEMS_PER_PAGE
   );
@@ -317,11 +320,7 @@ export default function OrdersPage() {
                         {o.deliveryBatchCode ?? "—"}
                       </td>
                       <td className="px-4 py-2 text-center">
-                        {o.actualDeliveryDate
-                          ? formatDate(o.actualDeliveryDate)
-                          : o.orderDate
-                          ? formatDate(o.orderDate)
-                          : "—"}
+                        {o.orderDate ? formatDate(o.orderDate) : "—"}
                       </td>
                       <td className="px-4 py-2 text-center">
                         {o.totalAmount != null
@@ -411,7 +410,7 @@ export default function OrdersPage() {
               <span className="font-medium">
                 {(currentPage - 1) * ITEMS_PER_PAGE + 1}
               </span>
-              –
+              {" – "}
               <span className="font-medium">
                 {Math.min(currentPage * ITEMS_PER_PAGE, filtered.length)}
               </span>{" "}

--- a/DakLakCoffeeSupplyChain/src/components/orders/OrderForm.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/orders/OrderForm.tsx
@@ -499,13 +499,14 @@ export default function OrderForm({
       });
     }
 
-    // Validate ngày giao thực tế không được trước ngày tạo đơn hàng
-    if (data.actualDeliveryDate && data.orderDate) {
+    // Validate ngày giao thực tế không được trước ngày hiện tại (chỉ khi EDIT)
+    if (isEdit && data.actualDeliveryDate) {
       const actualDate = new Date(data.actualDeliveryDate);
-      const orderDate = new Date(data.orderDate);
-      if (actualDate < orderDate) {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0); // Reset time to start of day
+      if (actualDate < today) {
         clientErrors.actualDeliveryDate = t(
-          "managerOrders.form.validation.actualDeliveryDateBeforeOrderDate"
+          "managerOrders.form.validation.actualDeliveryDateBeforeToday"
         );
       }
     }
@@ -897,8 +898,12 @@ export default function OrderForm({
         </div>
       )}
 
-      {/* DeliveryBatch */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {/* DeliveryBatch + DeliveryRound + ActualDeliveryDate */}
+      <div
+        className={`grid grid-cols-1 gap-4 ${
+          isEdit ? "md:grid-cols-3" : "md:grid-cols-2"
+        }`}
+      >
         {/* Đợt giao (create = select, edit = read-only) */}
         <div>
           <label className="block mb-1 text-sm font-medium">
@@ -970,91 +975,71 @@ export default function OrderForm({
           />
         </div>
 
-        {/* Ngày tạo đơn hàng */}
-        <div>
-          <label className="block mb-1 text-sm font-medium">
-            {t("managerOrders.form.fields.orderDate")}{" "}
-            <span className="text-red-500">*</span>
-          </label>
-          <DatePicker
-            value={form.orderDate}
-            onChange={(v) => setField("orderDate", v)}
-            placeholder="yyyy-MM-dd"
-            disabled={isEdit} // Disable khi edit vì ngày tạo không được thay đổi
-          />
-          {isEdit && (
-            <p className="text-xs text-gray-500 mt-1">
-              {t("managerOrders.form.fields.orderDateCannotChange")}
-            </p>
-          )}
-        </div>
-      </div>
-
-      {/* ActualDeliveryDate + Status */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div>
-          <label className="block mb-1 text-sm font-medium">
-            {t("managerOrders.form.fields.actualDeliveryDate")}
-          </label>
-          <DatePicker
-            value={form.actualDeliveryDate}
-            onChange={(v) => setField("actualDeliveryDate", v)}
-            placeholder="yyyy-MM-dd"
-          />
-        </div>
-
-        <div>
-          <label className="block mb-1 text-sm font-medium">
-            {t("managerOrders.form.fields.status")}{" "}
-            <span className="text-red-500">*</span>
-          </label>
-          {!isEdit ? (
-            // CREATE: cứng "Đang chuẩn bị", không thể thay đổi
-            <Input
-              value={t(`managerOrders.status.${form.status.toLowerCase()}`)}
-              readOnly
-              className="bg-muted/40 cursor-not-allowed"
-            />
-          ) : (
-            // EDIT: có thể chọn trạng thái
-            <select
-              className="w-full p-2 border rounded"
-              value={form.status}
-              onChange={(e) =>
-                setField("status", e.target.value as OrderStatus)
-              }
-            >
-              {Object.values(OrderStatus)
-                .filter((s) => s !== OrderStatus.Pending)
-                .map((s) => (
-                  <option key={s} value={s}>
-                    {t(`managerOrders.status.${s.toLowerCase()}`)}
-                  </option>
-                ))}
-            </select>
-          )}
-          {!isEdit && (
-            <p className="text-xs text-gray-500 mt-1">
-              {t("managerOrders.form.fields.statusCannotChange")}
-            </p>
-          )}
-        </div>
-
+        {/* Ngày giao thực tế - chỉ hiển thị khi EDIT */}
         {isEdit && (
           <div>
             <label className="block mb-1 text-sm font-medium">
-              {t("managerOrders.form.fields.cancelReason")}{" "}
-              {t("managerOrders.form.common.optional")}
+              {t("managerOrders.form.fields.actualDeliveryDate")}
             </label>
-            <Input
-              value={form.cancelReason ?? ""}
-              onChange={(e) => setField("cancelReason", e.target.value)}
-              placeholder={t("managerOrders.form.placeholders.cancelReason")}
-              disabled={form.status !== OrderStatus.Cancelled}
+            <DatePicker
+              value={form.actualDeliveryDate}
+              onChange={(v) => setField("actualDeliveryDate", v)}
+              placeholder="yyyy-MM-dd"
             />
           </div>
         )}
       </div>
+
+      {/* Status */}
+      <div>
+        <label className="block mb-1 text-sm font-medium">
+          {t("managerOrders.form.fields.status")}{" "}
+          <span className="text-red-500">*</span>
+        </label>
+        {!isEdit ? (
+          // CREATE: cứng "Đang chuẩn bị", không thể thay đổi
+          <Input
+            value={t(`managerOrders.status.${form.status.toLowerCase()}`)}
+            readOnly
+            className="bg-muted/40 cursor-not-allowed"
+          />
+        ) : (
+          // EDIT: có thể chọn trạng thái
+          <select
+            className="w-full p-2 border rounded"
+            value={form.status}
+            onChange={(e) => setField("status", e.target.value as OrderStatus)}
+          >
+            {Object.values(OrderStatus)
+              .filter((s) => s !== OrderStatus.Pending)
+              .map((s) => (
+                <option key={s} value={s}>
+                  {t(`managerOrders.status.${s.toLowerCase()}`)}
+                </option>
+              ))}
+          </select>
+        )}
+        {!isEdit && (
+          <p className="text-xs text-gray-500 mt-1">
+            {t("managerOrders.form.fields.statusCannotChange")}
+          </p>
+        )}
+      </div>
+
+      {/* Cancel Reason - chỉ hiển thị khi EDIT và status là Cancelled */}
+      {isEdit && form.status === OrderStatus.Cancelled && (
+        <div>
+          <label className="block mb-1 text-sm font-medium">
+            {t("managerOrders.form.fields.cancelReason")}{" "}
+            <span className="text-red-500">*</span>
+          </label>
+          <Input
+            value={form.cancelReason ?? ""}
+            onChange={(e) => setField("cancelReason", e.target.value)}
+            placeholder={t("managerOrders.form.placeholders.cancelReason")}
+          />
+        </div>
+      )}
 
       {/* Note */}
       <div>
@@ -1100,10 +1085,7 @@ export default function OrderForm({
                 {t("managerOrders.form.table.headers.quantity")}{" "}
                 <span className="text-red-500">*</span>
               </span>
-              <span>
-                {t("managerOrders.form.table.headers.unitPrice")}{" "}
-                <span className="text-red-500">*</span>
-              </span>
+              <span>{t("managerOrders.form.table.headers.unitPrice")}</span>
               <span>{t("managerOrders.form.table.headers.discount")}</span>
               <span>{t("managerOrders.form.table.headers.note")}</span>
               <span></span>
@@ -1222,52 +1204,25 @@ export default function OrderForm({
                   </p>
                 )}
 
-                {/* Đơn giá */}
+                {/* Đơn giá - tự động từ mặt hàng đợt giao */}
                 <Input
                   type="number"
                   min={0}
                   step={1000}
                   value={row.unitPrice}
-                  onChange={(e) =>
-                    updateRow(
-                      idx,
-                      "unitPrice",
-                      e.target.value === "" ? "" : Number(e.target.value)
-                    )
-                  }
-                  className={`no-spinner ${
-                    hasOrderItemError(idx, "unitPrice") ? "border-red-500" : ""
-                  }`}
-                  onKeyDown={(e) => {
-                    if (e.key === "-" || e.key.toLowerCase() === "e")
-                      e.preventDefault();
-                  }}
+                  readOnly
+                  className="bg-muted/40 cursor-not-allowed"
                 />
-                {hasOrderItemError(idx, "unitPrice") && (
-                  <p className="text-red-500 text-xs mt-1 md:col-span-7">
-                    {getOrderItemError(idx, "unitPrice")}
-                  </p>
-                )}
 
-                {/* Giảm trừ (%) */}
+                {/* Giảm trừ (%) - tự động từ mặt hàng đợt giao */}
                 <Input
                   type="number"
                   min={0}
                   max={100}
                   step={0.1}
                   value={row.discountAmount ?? 0}
-                  onChange={(e) =>
-                    updateRow(
-                      idx,
-                      "discountAmount",
-                      e.target.value === "" ? "" : Number(e.target.value)
-                    )
-                  }
-                  className="no-spinner"
-                  onKeyDown={(e) => {
-                    if (e.key === "-" || e.key.toLowerCase() === "e")
-                      e.preventDefault();
-                  }}
+                  readOnly
+                  className="bg-muted/40 cursor-not-allowed"
                 />
 
                 {/* Ghi chú */}

--- a/DakLakCoffeeSupplyChain/src/i18n/locales/en.json
+++ b/DakLakCoffeeSupplyChain/src/i18n/locales/en.json
@@ -5377,7 +5377,7 @@
           "orderCode": "Order Code",
           "contractNumber": "Contract Number",
           "deliveryBatchCode": "Delivery Batch Code",
-          "deliveryDate": "Delivery Date",
+          "deliveryDate": "Creation Date",
           "totalAmount": "Total Amount (VND)",
           "status": "Status",
           "actions": "Actions"
@@ -5391,7 +5391,7 @@
           "failed": "Failed"
         },
         "tooltips": {
-          "deliveryDate": "Actual delivery date if available, otherwise order date.",
+          "deliveryDate": "The date when the order was created.",
           "totalAmount": "Total monetary value of the order (after reconciliation).",
           "viewDetails": "View Details",
           "edit": "Edit",
@@ -5579,6 +5579,7 @@
           "orderCode": "Order Code:",
           "contractNumber": "Contract Number:",
           "deliveryRound": "Delivery Round:",
+          "orderDate": "Creation Date:",
           "deliveryDate": "Delivery Date:",
           "totalAmount": "Total Amount (VND):",
           "status": "Status:",
@@ -5586,6 +5587,7 @@
           "cancelReason": "Cancel Reason:"
         },
         "tooltips": {
+          "orderDate": "The date when the order was created.",
           "deliveryDate": "Actual delivery date if available, otherwise order date.",
           "totalAmount": "Total monetary value of the order."
         }

--- a/DakLakCoffeeSupplyChain/src/i18n/locales/vi.json
+++ b/DakLakCoffeeSupplyChain/src/i18n/locales/vi.json
@@ -5433,7 +5433,7 @@
            "orderCode": "Mã đơn hàng",
            "contractNumber": "Số hợp đồng",
            "deliveryBatchCode": "Mã đợt giao",
-           "deliveryDate": "Ngày giao",
+           "deliveryDate": "Ngày tạo",
            "totalAmount": "Tổng giá trị (VNĐ)",
            "status": "Trạng thái",
            "actions": "Hành động"
@@ -5447,7 +5447,7 @@
            "failed": "Giao thất bại"
          },
         "tooltips": {
-          "deliveryDate": "Ngày giao thực tế nếu có, không thì ngày đặt.",
+          "deliveryDate": "Ngày tạo đơn hàng.",
           "totalAmount": "Tổng giá trị tiền của đơn hàng (sau đối soát).",
           "viewDetails": "Xem chi tiết",
           "edit": "Chỉnh sửa",
@@ -5635,6 +5635,7 @@
           "orderCode": "Mã đơn hàng:",
           "contractNumber": "Số hợp đồng:",
           "deliveryRound": "Đợt giao:",
+          "orderDate": "Ngày tạo:",
           "deliveryDate": "Ngày giao:",
           "totalAmount": "Tổng giá trị (VNĐ):",
           "status": "Trạng thái:",
@@ -5642,7 +5643,8 @@
           "cancelReason": "Lý do huỷ:"
         },
         "tooltips": {
-          "deliveryDate": "Ngày giao thực tế nếu có, không thì ngày đặt.",
+          "orderDate": "Ngày tạo đơn hàng.",
+          "deliveryDate": "Ngày giao thực tế.",
           "totalAmount": "Tổng giá trị tiền của đơn hàng."
         }
       },


### PR DESCRIPTION
## ☕ Feature: Manager – Order Form & List UX polish

### 📌 Objective
Improve the Order workflow for Business Manager/Staff by making unit price/discount immutable (derived from batch item), tightening conditional fields, refining responsive layout, and focusing the Orders list on creation time with newest-first sorting.

---

### ✅ Key Changes
- Lock **UnitPrice** and **DiscountAmount** in `OrderForm` (auto-filled from the selected batch item; user cannot edit).
- Layout tweaks:  
  - **Create**: *Delivery Batch* & *Delivery Round* → **1/2 + 1/2** in one row.  
  - **Edit**: *Delivery Batch*, *Delivery Round*, *Actual Delivery Date* → **1/3 + 1/3 + 1/3** in one row.
- Show **Cancel Reason** only when **Status = Canceled**.
- Orders list: display **CreatedAt** only; default filter **now → past** and **sort newest first**.
- i18n: update EN/VI strings for new labels/tooltips/messages.

---

### 🧱 Affected Files
- `DakLakCoffeeSupplyChain/src/app/dashboard/manager/orders/[id]/page.tsx`
- `DakLakCoffeeSupplyChain/src/app/dashboard/manager/orders/page.tsx`
- `DakLakCoffeeSupplyChain/src/components/orders/OrderForm.tsx`
- `DakLakCoffeeSupplyChain/src/i18n/locales/en.json`
- `DakLakCoffeeSupplyChain/src/i18n/locales/vi.json`

---

### 📁 Added
- *(None)*

---

### 🛠️ How to Test
1. Go to **`/dashboard/manager/orders`**.
2. **Create** an order:
   - Select *Delivery Batch* & *Round*, add an item via **Product** tied to that batch item.
   - Verify **UnitPrice** and **Discount** auto-fill and are **read-only**.
   - Confirm layout is **1/2 + 1/2** for Batch/Round.
3. **Edit** an order:
   - Verify **Batch / Round / Actual Delivery Date** render **1/3 + 1/3 + 1/3** in one row.
   - Change **Status = Canceled** → **Cancel Reason** appears; other statuses → hidden.
4. **Orders list**:
   - Only **CreatedAt** is shown.
   - Default filter is **now → past**; list is **newest first**.

---

### 🧪 Test Cases
- [x] ✅ Auto-fill & lock pricing from batch item (not editable).
- [x] ✅ Create layout: Batch & Round **1/2 + 1/2**.
- [x] ✅ Edit layout: Batch/Round/ActualDeliveryDate **1/3 + 1/3 + 1/3**.
- [x] ✅ Cancel Reason visible only when **Status = Canceled**.
- [x] ✅ Orders list shows **CreatedAt** only; default **now → past**; **newest first**.
- [x] ✅ i18n strings load correctly in EN/VI.

---

### 🔍 Notes
- UnitPrice/Discount are **derived** from the selected **batch item** to align with backend rules.
- Delivery-related dates intentionally hidden in list view to emphasize creation chronology.
- Check timezone consistency when validating CreatedAt sorting.

---

### 🔗 Related
- Modules: **Orders**, **Contract Delivery Batch**
- Roles: **BusinessManager**, **BusinessStaff**

---

### ☑️ Checklist (before PR)
- [ ] All create/edit/list flows manually tested
- [ ] No console errors/warnings
- [ ] Clear commit message & PR description
