### PR TITLE
feat(shipments-ui): require Shipment Start Date; auto-fill Quantity when selecting Order Item (update en/vi i18n messages)

### DIFF
--- a/DakLakCoffeeSupplyChain/src/components/shipments/ShipmentForm.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/shipments/ShipmentForm.tsx
@@ -59,7 +59,7 @@ export default function ShipmentForm({
 
   const [formData, setFormData] = useState<FormState | null>(null);
   const [orderItems, setOrderItems] = useState<
-    { orderItemId: string; productName: string }[]
+    { orderItemId: string; productName: string; quantity: number }[]
   >([]);
   const [orderOptions, setOrderOptions] = useState<
     { orderId: string; orderCode: string }[]
@@ -109,7 +109,13 @@ export default function ShipmentForm({
     (async () => {
       try {
         const detail = await getOrderDetails(oid);
-        setOrderItems(detail.orderItems || []);
+        setOrderItems(
+          (detail.orderItems || []).map((item: any) => ({
+            orderItemId: item.orderItemId,
+            productName: item.productName,
+            quantity: item.quantity || 0,
+          }))
+        );
       } catch (e) {
         console.error(e);
         toast.error(t("shipments.form.validation.loadOrderItemsFailed"));
@@ -207,6 +213,8 @@ export default function ShipmentForm({
       return toast.error(t("shipments.form.validation.selectOrder"));
     if (!data.deliveryStaffId)
       return toast.error(t("shipments.form.validation.selectStaff"));
+    if (!data.shippedAt)
+      return toast.error(t("shipments.form.validation.selectShippedAt"));
 
     const shippedAtStr = data.shippedAt
       ? toDateOnly(data.shippedAt)
@@ -405,7 +413,8 @@ export default function ShipmentForm({
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className="flex flex-col gap-2">
           <label className="text-sm font-medium">
-            {t("shipments.form.shippedAt")}
+            {t("shipments.form.shippedAt")}{" "}
+            <span className="text-red-500">*</span>
           </label>
           <DatePicker
             className="h-10"
@@ -450,7 +459,20 @@ export default function ShipmentForm({
           <div key={idx} className="grid grid-cols-1 md:grid-cols-6 gap-3 mb-2">
             <select
               value={row.orderItemId}
-              onChange={(e) => updateRow(idx, "orderItemId", e.target.value)}
+              onChange={(e) => {
+                const orderItemId = e.target.value;
+                updateRow(idx, "orderItemId", orderItemId);
+
+                // Tự động cập nhật số lượng từ orderItem tương ứng
+                if (orderItemId) {
+                  const selectedItem = orderItems.find(
+                    (item) => item.orderItemId === orderItemId
+                  );
+                  if (selectedItem) {
+                    updateRow(idx, "quantity", selectedItem.quantity);
+                  }
+                }
+              }}
               className="p-2 border rounded h-10"
             >
               <option value="">{t("shipments.form.selectOrderItem")}</option>

--- a/DakLakCoffeeSupplyChain/src/i18n/locales/en.json
+++ b/DakLakCoffeeSupplyChain/src/i18n/locales/en.json
@@ -4824,7 +4824,8 @@
         "selectOrder": "Please select an order.",
         "selectStaff": "Please select delivery staff.",
         "loadOrderItemsFailed": "Cannot load order items list.",
-        "saveFailed": "An error occurred while saving the shipment."
+        "saveFailed": "An error occurred while saving the shipment.",
+        "selectShippedAt": "Please select the shipment start date"
       },
       "success": {
         "update": "Shipment updated successfully!",

--- a/DakLakCoffeeSupplyChain/src/i18n/locales/vi.json
+++ b/DakLakCoffeeSupplyChain/src/i18n/locales/vi.json
@@ -4876,7 +4876,8 @@
         "selectOrder": "Vui lòng chọn đơn hàng.",
         "selectStaff": "Vui lòng chọn nhân viên giao.",
         "loadOrderItemsFailed": "Không thể tải danh sách mặt hàng đơn hàng.",
-        "saveFailed": "Đã xảy ra lỗi khi lưu chuyến giao."
+        "saveFailed": "Đã xảy ra lỗi khi lưu chuyến giao.",
+        "selectShippedAt": "Vui lòng chọn ngày bắt đầu giao"
       },
       "success": {
         "update": "Cập nhật lô giao thành công!",


### PR DESCRIPTION
## ☕ Feature: Manager – Shipment Form Required Start Date & Auto-fill Quantity

### 📌 Objective
Enforce **Shipment Start Date** as a required field and enable **auto-fill Quantity** when selecting an Order Item in the Shipment Form. This improves data accuracy and reduces manual input for managers.

---

### ✅ Main Changes
- Added validation: Shipment Start Date is mandatory
- Implemented auto-fill for Quantity when an Order Item is selected
- Updated EN/VI i18n messages accordingly

---

### 📁 Affected Files
- `src/components/shipments/ShipmentForm.tsx`
- `src/i18n/locales/en.json`
- `src/i18n/locales/vi.json`

---

### 🧪 How to Test
1. Navigate to: `/dashboard/manager/shipments/create`
2. Test form behavior:
   - Try creating a shipment without entering **Shipment Start Date** → should show validation error
   - Select an **Order Item** → Quantity should be auto-filled correctly

---

### 🧪 Test Case
- [x] ✅ Shipment cannot be created without Shipment Start Date
- [x] ✅ Quantity auto-fills when Order Item is selected
- [x] ❌ No regression in form submission and layout

---

### 🔍 Notes
- Purely front-end/UI + validation update
- No API changes required
- i18n updated for both EN and VI

---

### 🔗 Related
- Module: `Shipments`
- Role: `Manager`

---

### ☑️ Checklist (before PR)
- [x] Tested validation and auto-fill logic
- [x] Checked console for errors/warnings
- [x] Commit & description follow clear naming
