### PR TITLE
feat(contract-delivery-batch-ui): filter contracts with remaining deliveries and add bilingual instruction in ContractDeliveryBatchForm (update en/vi i18n & API usage)

### DIFF
--- a/DakLakCoffeeSupplyChain/src/app/dashboard/manager/contract-delivery-batches/create/page.tsx
+++ b/DakLakCoffeeSupplyChain/src/app/dashboard/manager/contract-delivery-batches/create/page.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from "react";
 import ContractDeliveryBatchForm, {
   ContractOption,
 } from "@/components/contract-delivery-batches/ContractDeliveryBatchForm";
-import { getAllContracts } from "@/lib/api/contracts"; // trả [{contractId, contractNumber}]
+import { getAllContracts, getContractDetails } from "@/lib/api/contracts"; // trả [{contractId, contractNumber}]
+import { getContractDeliveryBatchesByContractId } from "@/lib/api/contractDeliveryBatches";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
@@ -18,10 +19,65 @@ export default function CreateDeliveryBatchPage() {
   useEffect(() => {
     (async () => {
       try {
-        const data = await getAllContracts();
-        setOptions(data);
+        const allContracts = await getAllContracts();
+        console.log("Tất cả hợp đồng:", allContracts);
+
+        // Lọc chỉ những hợp đồng chưa đủ đợt giao hàng
+        const availableContracts: ContractOption[] = [];
+
+        for (const contract of allContracts) {
+          try {
+            // Lấy danh sách đợt giao hàng của hợp đồng này
+            const existingBatches =
+              await getContractDeliveryBatchesByContractId(contract.contractId);
+
+            // Lấy chi tiết hợp đồng để kiểm tra tổng khối lượng
+            const contractDetails = await getContractDetails(
+              contract.contractId
+            );
+            const totalPlannedQuantity = contractDetails.totalQuantity || 0;
+
+            // Tính tổng khối lượng đã được lên kế hoạch giao
+            const totalPlannedInBatches = existingBatches.reduce(
+              (sum, batch) => {
+                return sum + (batch.totalPlannedQuantity || 0);
+              },
+              0
+            );
+
+            // Chỉ hiển thị hợp đồng chưa đủ đợt giao hàng
+            if (totalPlannedInBatches < totalPlannedQuantity) {
+              const remainingQuantity =
+                totalPlannedQuantity - totalPlannedInBatches;
+
+              availableContracts.push({
+                contractId: contract.contractId,
+                contractNumber: contract.contractNumber,
+                remainingQuantity: remainingQuantity,
+                totalQuantity: totalPlannedQuantity,
+                existingBatches: existingBatches.length,
+              });
+            }
+          } catch (e) {
+            console.error(
+              `Lỗi khi kiểm tra hợp đồng ${contract.contractNumber}:`,
+              e
+            );
+            // Nếu lỗi, vẫn hiển thị hợp đồng này để tránh mất dữ liệu
+            availableContracts.push({
+              contractId: contract.contractId,
+              contractNumber: contract.contractNumber,
+              remainingQuantity: 0,
+              totalQuantity: 0,
+              existingBatches: 0,
+            });
+          }
+        }
+
+        console.log("Hợp đồng khả dụng:", availableContracts);
+        setOptions(availableContracts);
       } catch (e) {
-        console.error(e);
+        console.error("Lỗi khi load hợp đồng:", e);
         toast.error(t("contractDeliveryBatches.create.errors.loadContracts"));
       } finally {
         setLoading(false);
@@ -29,7 +85,12 @@ export default function CreateDeliveryBatchPage() {
     })();
   }, []);
 
-  if (loading) return <div className="p-6 text-gray-500">{t("contractDeliveryBatches.create.loading")}</div>;
+  if (loading)
+    return (
+      <div className="p-6 text-gray-500">
+        {t("contractDeliveryBatches.create.loading")}
+      </div>
+    );
 
   return (
     <div className="p-6">

--- a/DakLakCoffeeSupplyChain/src/components/contract-delivery-batches/ContractDeliveryBatchForm.tsx
+++ b/DakLakCoffeeSupplyChain/src/components/contract-delivery-batches/ContractDeliveryBatchForm.tsx
@@ -15,6 +15,7 @@ import {
   ContractDeliveryBatchCreateDto,
   ContractDeliveryBatchUpdateDto,
   getContractDeliveryBatchById,
+  getContractDeliveryBatchesByContractId,
 } from "@/lib/api/contractDeliveryBatches";
 import {
   ContractDeliveryBatchStatus,
@@ -24,7 +25,13 @@ import {
 import { toDateOnly, fromDateOnly, getErrorMessage } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 
-export type ContractOption = { contractId: string; contractNumber: string };
+export type ContractOption = {
+  contractId: string;
+  contractNumber: string;
+  remainingQuantity?: number;
+  totalQuantity?: number;
+  existingBatches?: number;
+};
 
 // Form State
 type DeliveryBatchFormState = {
@@ -199,6 +206,47 @@ export default function ContractDeliveryBatchForm({
       }
     })();
   }, [formData?.contractId]);
+
+  // useEffect để kiểm tra và cập nhật deliveryRound dựa trên số đợt giao hiện có
+  useEffect(() => {
+    const cid = formData?.contractId;
+    if (!cid || isEdit) return; // Chỉ áp dụng cho create mode
+
+    (async () => {
+      try {
+        // Lấy danh sách đợt giao hàng của hợp đồng này
+        const existingBatches = await getContractDeliveryBatchesByContractId(
+          cid
+        );
+
+        // Tìm deliveryRound lớn nhất hiện có
+        const maxRound = existingBatches.reduce((max, batch) => {
+          return Math.max(max, batch.deliveryRound || 0);
+        }, 0);
+
+        // Cập nhật deliveryRound thành round tiếp theo
+        setFormData((prev) =>
+          prev
+            ? {
+                ...prev,
+                deliveryRound: maxRound + 1,
+              }
+            : null
+        );
+      } catch (e) {
+        console.error("Không thể kiểm tra đợt giao hàng hiện có:", e);
+        // Nếu lỗi, giữ nguyên deliveryRound = 1
+        setFormData((prev) =>
+          prev
+            ? {
+                ...prev,
+                deliveryRound: 1,
+              }
+            : null
+        );
+      }
+    })();
+  }, [formData?.contractId, isEdit]);
 
   // useEffect tự động cập nhật trạng thái khi khối lượng đã giao thay đổi
   useEffect(() => {
@@ -750,6 +798,14 @@ export default function ContractDeliveryBatchForm({
             {contractOptions.map((c) => (
               <option key={c.contractId} value={c.contractId}>
                 {c.contractNumber}
+                {c.remainingQuantity !== undefined &&
+                  c.totalQuantity !== undefined &&
+                  c.remainingQuantity > 0 &&
+                  ` - Còn lại: ${c.remainingQuantity.toLocaleString()} kg / ${c.totalQuantity.toLocaleString()} kg`}
+                {c.existingBatches !== undefined &&
+                  c.existingBatches > 0 &&
+                  ` (${c.existingBatches} đợt giao)`}
+                {c.remainingQuantity === 0 && ` - Đã đủ đợt giao`}
               </option>
             ))}
           </select>
@@ -758,6 +814,40 @@ export default function ContractDeliveryBatchForm({
               {getFieldError("contractId")}
             </p>
           )}
+
+          {/* Thông báo hướng dẫn */}
+          <div className="mt-2 p-3 bg-blue-50 border border-blue-200 rounded-md">
+            <div className="flex items-start gap-2">
+              <div className="text-blue-600 mt-0.5">ℹ️</div>
+              <div className="text-blue-800 text-sm">
+                <p className="font-medium mb-1">
+                  {t("contractDeliveryBatches.form.contractSelection.title")}
+                </p>
+                <ul className="text-xs space-y-1">
+                  <li>
+                    {t(
+                      "contractDeliveryBatches.form.contractSelection.onlyAvailableContracts"
+                    )}
+                  </li>
+                  <li>
+                    {t(
+                      "contractDeliveryBatches.form.contractSelection.displayFormat"
+                    )}
+                  </li>
+                  <li>
+                    {t(
+                      "contractDeliveryBatches.form.contractSelection.autoDeliveryRound"
+                    )}
+                  </li>
+                  <li>
+                    {t(
+                      "contractDeliveryBatches.form.contractSelection.completedContractsHidden"
+                    )}
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
         </div>
       )}
 

--- a/DakLakCoffeeSupplyChain/src/i18n/locales/en.json
+++ b/DakLakCoffeeSupplyChain/src/i18n/locales/en.json
@@ -6837,6 +6837,13 @@
       },
       "status": {
         "defaultNote": " New delivery batch will have \"In Progress\" status by default"
+      },
+      "contractSelection": {
+        "title": "Contract Selection Guide:",
+        "onlyAvailableContracts": "• Only shows contracts that don't have enough delivery batches",
+        "displayFormat": "• Display format: Contract Number - Remaining: X kg / Total: Y kg (Z batches)",
+        "autoDeliveryRound": "• Delivery Round will automatically be updated to the next round",
+        "completedContractsHidden": "• Contracts with sufficient delivery batches will not appear in the list"
       }
     },
     "detail": {

--- a/DakLakCoffeeSupplyChain/src/i18n/locales/vi.json
+++ b/DakLakCoffeeSupplyChain/src/i18n/locales/vi.json
@@ -6894,6 +6894,13 @@
       },
       "status": {
         "defaultNote": " Đợt giao mới sẽ có trạng thái \"Đang thực hiện\" mặc định"
+      },
+      "contractSelection": {
+        "title": "Hướng dẫn chọn hợp đồng:",
+        "onlyAvailableContracts": "• Chỉ hiển thị hợp đồng chưa đủ đợt giao hàng",
+        "displayFormat": "• Thông tin hiển thị: Số hợp đồng - Còn lại: X kg / Tổng: Y kg (Z đợt giao)",
+        "autoDeliveryRound": "• Delivery Round sẽ tự động được cập nhật thành round tiếp theo",
+        "completedContractsHidden": "• Hợp đồng đã đủ đợt giao sẽ không xuất hiện trong danh sách"
       }
     },
     "detail": {

--- a/DakLakCoffeeSupplyChain/src/lib/api/contractDeliveryBatches.ts
+++ b/DakLakCoffeeSupplyChain/src/lib/api/contractDeliveryBatches.ts
@@ -82,6 +82,21 @@ export async function getContractDeliveryBatchById(
   return response.data;
 }
 
+// API: Lấy danh sách đợt giao hàng theo contractId
+// Sử dụng API getAllContractDeliveryBatches và lọc theo contractId
+export async function getContractDeliveryBatchesByContractId(
+  contractId: string
+): Promise<ContractDeliveryBatchViewAllDto[]> {
+  try {
+    const allBatches = await getAllContractDeliveryBatches();
+    // Lọc theo contractId
+    return allBatches.filter(batch => batch.contractId === contractId);
+  } catch (error) {
+    console.error("Lỗi khi lấy đợt giao hàng theo contractId:", error);
+    return [];
+  }
+}
+
 // API: Tạo mới một đợt giao hàng
 export async function createContractDeliveryBatch(dto: ContractDeliveryBatchCreateDto) {
   return api.post("/ContractDeliveryBatchs", {


### PR DESCRIPTION
## ☕ Feature: Manager – Filter Contracts with Remaining Deliveries & Bilingual Instruction

### 📌 Objective
Allow **BusinessManager** to only see contracts that still have remaining delivery batches when creating a new delivery batch.  
Provide clear bilingual instruction (EN/VI) to guide managers in selecting eligible contracts.

---

### ✅ Key Changes
- Updated `ContractDeliveryBatchForm.tsx` to filter out contracts that already fulfilled all planned deliveries  
- Implemented logic to calculate remaining quantity and next delivery round from existing batches  
- Enhanced dropdown display with detailed contract info: `Remaining / Total (Batch Count)`  
- Added bilingual guidance text (English & Vietnamese) using `i18n` (`en.json`, `vi.json`)  
- Updated `create/page.tsx` and API usage to fetch all delivery batches via `getAllContractDeliveryBatches()` and filter by `contractId`  

---

### 📁 Affected Files
- `src/app/dashboard/manager/contract-delivery-batches/create/page.tsx`  
- `src/components/contract-delivery-batches/ContractDeliveryBatchForm.tsx`  
- `src/lib/api/contractDeliveryBatches.ts`  
- `src/i18n/locales/en.json`  
- `src/i18n/locales/vi.json`  

---

### 🧪 How to Test
1. Go to: `/dashboard/manager/contract-delivery-batches/create`  
2. Check the **Contract dropdown**:  
   - Contracts that already have enough batches should not appear  
   - Eligible contracts show remaining quantity, total, and existing batch count  
3. Verify bilingual guidance appears correctly when switching language  

---

### 🧪 Test Cases
- [x] ✅ Contract with remaining planned quantity → visible in dropdown  
- [x] ❌ Contract fully fulfilled → not shown in dropdown  
- [x] ✅ Dropdown displays: `ContractCode – Remaining: X kg / Total: Y kg (Z batches)`  
- [x] ✅ DeliveryRound auto-set to `maxRound + 1`  

---

### 🔍 Notes
- Filtering logic handled on frontend using `getAllContracts` + `getAllContractDeliveryBatches`  
- Fallback: if API fails, all contracts still load to prevent blocking manager  
- Guidance message is fully bilingual (EN/VI) and auto-switches with locale  

---

### 🔗 Related
- Module: `ContractDeliveryBatch`, `Contract`  
- Roles: `BusinessManager`  

---

### ☑️ Checklist (before PR)
- [ ] Tested dropdown filtering with multiple contracts  
- [ ] Verified bilingual instruction in EN/VI  
- [ ] Checked for console errors or warnings  
- [ ] Commit message and PR description are clear  
